### PR TITLE
Add rlp-to-protobuf command

### DIFF
--- a/cmd/rlp-to-protobuf/flags.go
+++ b/cmd/rlp-to-protobuf/flags.go
@@ -1,0 +1,39 @@
+package main
+
+import "github.com/urfave/cli/v2"
+
+var (
+	WorkersFlag = cli.IntFlag{
+		Name:    "workers",
+		Aliases: []string{"w"},
+		Usage:   "determines number of workers",
+		Value:   4,
+	}
+	SrcDbFlag = cli.PathFlag{
+		Name:     "src",
+		Usage:    "Source Aida DB",
+		Required: true,
+	}
+	DstDbFlag = cli.PathFlag{
+		Name:     "dst",
+		Usage:    "Destination Aida DB",
+		Required: true,
+	}
+	SkipTransferTxsFlag = cli.BoolFlag{
+		Name:  "skip-transfer-txs",
+		Usage: "Skip executing transactions that only transfer ETH",
+	}
+	SkipCallTxsFlag = cli.BoolFlag{
+		Name:  "skip-call-txs",
+		Usage: "Skip executing CALL transactions to accounts with contract bytecode",
+	}
+	SkipCreateTxsFlag = cli.BoolFlag{
+		Name:  "skip-create-txs",
+		Usage: "Skip executing CREATE transactions",
+	}
+	BlockSegmentFlag = cli.StringFlag{
+		Name:     "block-segment",
+		Usage:    "Single block segment (e.g. 1001, 1_001, 1_001-2_000, 1-2k, 1-2M)",
+		Required: true,
+	}
+)

--- a/cmd/rlp-to-protobuf/main.go
+++ b/cmd/rlp-to-protobuf/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/urfave/cli/v2"
+)
+
+func main() {
+	app := &cli.App{
+		Name:   "rlp-to-protobuf",
+		Usage:  "Convert rlp encoded substate to protobuf encoded substate",
+		Action: RunRlpToProtobuf,
+		Flags: []cli.Flag{
+			&WorkersFlag,
+			&SrcDbFlag,
+			&DstDbFlag,
+			&SkipTransferTxsFlag,
+			&SkipCallTxsFlag,
+			&SkipCreateTxsFlag,
+			&BlockSegmentFlag,
+		},
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/rlp-to-protobuf/rlp_to_protobuf.go
+++ b/cmd/rlp-to-protobuf/rlp_to_protobuf.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/syndtr/goleveldb/leveldb/opt"
+
+	"github.com/0xsoniclabs/substate/db"
+	"github.com/0xsoniclabs/substate/substate"
+	"github.com/urfave/cli/v2"
+)
+
+type rlpToProtobufCommand struct {
+	src db.SubstateDB
+	dst db.SubstateDB
+	ctx *cli.Context
+}
+
+func (c *rlpToProtobufCommand) execute() error {
+
+	segment, err := parseBlockSegment(c.ctx.String(BlockSegmentFlag.Name))
+	if err != nil {
+		return err
+	}
+
+	taskPool := &db.SubstateTaskPool{
+		Name:     "rlp-to-protobuf",
+		TaskFunc: c.performSubstateUpgrade,
+
+		First: segment.First,
+		Last:  segment.Last,
+
+		Workers:         c.ctx.Int(WorkersFlag.Name),
+		SkipTransferTxs: c.ctx.Bool(SkipTransferTxsFlag.Name),
+		SkipCallTxs:     c.ctx.Bool(SkipCallTxsFlag.Name),
+		SkipCreateTxs:   c.ctx.Bool(SkipCreateTxsFlag.Name),
+
+		Ctx: c.ctx,
+
+		DB: c.src,
+	}
+	err = c.dst.SetSubstateEncoding("protobuf")
+	if err != nil {
+		return err
+	}
+	return taskPool.Execute()
+}
+
+func (c *rlpToProtobufCommand) performSubstateUpgrade(
+	block uint64,
+	tx int,
+	substate *substate.Substate,
+	taskPool *db.SubstateTaskPool,
+) error {
+	err := c.dst.PutSubstate(substate)
+	if err != nil {
+		return fmt.Errorf("failed to put substate: %w", err)
+	}
+	return nil
+}
+
+func RunRlpToProtobuf(ctx *cli.Context) error {
+	// Open old DB
+	src, err := db.NewSubstateDB(ctx.String(SrcDbFlag.Name), &opt.Options{
+		OpenFilesCacheCapacity: 1024,
+		BlockCacheCapacity:     50 * opt.MiB,
+		WriteBuffer:            25 * opt.MiB,
+		ReadOnly:               true,
+	}, nil, nil)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	// Open new DB
+	dst, err := db.NewSubstateDB(ctx.String(DstDbFlag.Name), &opt.Options{
+		OpenFilesCacheCapacity: 1024,
+		BlockCacheCapacity:     50 * opt.MiB,
+		WriteBuffer:            25 * opt.MiB,
+		ReadOnly:               false,
+	}, nil, nil)
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+
+	command := rlpToProtobufCommand{
+		src: src,
+		dst: dst,
+		ctx: ctx,
+	}
+	return command.execute()
+}

--- a/cmd/rlp-to-protobuf/rlp_to_protobuf_test.go
+++ b/cmd/rlp-to-protobuf/rlp_to_protobuf_test.go
@@ -1,0 +1,400 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/substate/db"
+	"github.com/0xsoniclabs/substate/substate"
+	"github.com/0xsoniclabs/substate/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRLPtoProtobufCommand_ParsingFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	src := db.NewMockSubstateDB(ctrl)
+	dst := db.NewMockSubstateDB(ctrl)
+
+	set := flag.NewFlagSet("test", 0)
+	_ = set.String(BlockSegmentFlag.Name, "0-abc", "")
+	_ = set.String(WorkersFlag.Name, "1", "")
+	ctx := cli.NewContext(&cli.App{}, set, nil)
+
+	command := rlpToProtobufCommand{
+		src: src,
+		dst: dst,
+		ctx: ctx,
+	}
+
+	err := command.execute()
+	expected := errors.New("invalid block segment string: \"0-abc\"")
+	assert.Equal(t, expected, err)
+}
+
+func TestRLPtoProtobufCommand_SetEncodingFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	src := db.NewMockSubstateDB(ctrl)
+	dst := db.NewMockSubstateDB(ctrl)
+
+	set := flag.NewFlagSet("test", 0)
+	_ = set.String(BlockSegmentFlag.Name, "0-2", "")
+	_ = set.String(WorkersFlag.Name, "1", "")
+	ctx := cli.NewContext(&cli.App{}, set, nil)
+	mockErr := errors.New("error")
+
+	dst.EXPECT().SetSubstateEncoding("protobuf").Return(mockErr)
+
+	command := rlpToProtobufCommand{
+		src: src,
+		dst: dst,
+		ctx: ctx,
+	}
+
+	err := command.execute()
+
+	assert.Equal(t, mockErr, err)
+}
+
+func TestRLPtoProtobufCommand_ExecuteUpgradeFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	src := db.NewMockSubstateDB(ctrl)
+	dst := db.NewMockSubstateDB(ctrl)
+
+	set := flag.NewFlagSet("test", 0)
+	_ = set.String(BlockSegmentFlag.Name, "0-2", "")
+	_ = set.String(WorkersFlag.Name, "1", "")
+	ctx := cli.NewContext(&cli.App{}, set, nil)
+
+	mockErr := errors.New("error")
+	command := rlpToProtobufCommand{
+		src: src,
+		dst: dst,
+		ctx: ctx,
+	}
+
+	input0 := &substate.Substate{
+		InputSubstate:  substate.NewWorldState(),
+		OutputSubstate: substate.NewWorldState(),
+		Env: &substate.Env{
+			Coinbase:   types.Address{1},
+			Difficulty: new(big.Int).SetUint64(1),
+			GasLimit:   1,
+			Number:     1,
+			Timestamp:  1,
+			BaseFee:    new(big.Int).SetUint64(1),
+		},
+		Message: substate.NewMessage(
+			1,
+			true,
+			new(big.Int).SetUint64(1),
+			1,
+			types.Address{1},
+			new(types.Address),
+			new(big.Int).SetUint64(1),
+			[]byte{1},
+			nil,
+			new(int32),
+			types.AccessList{},
+			new(big.Int).SetUint64(1),
+			new(big.Int).SetUint64(1),
+			new(big.Int).SetUint64(1),
+			make([]types.Hash, 0),
+		),
+		Result:      substate.NewResult(1, types.Bloom{}, []*types.Log{}, types.Address{}, 1),
+		Block:       37_534_834,
+		Transaction: 1,
+	}
+
+	dst.EXPECT().SetSubstateEncoding("protobuf").Return(nil)
+	gomock.InOrder(
+		src.EXPECT().GetBlockSubstates(uint64(0)).Return(map[int]*substate.Substate{
+			0: input0,
+		}, nil),
+		src.EXPECT().GetBlockSubstates(uint64(1)).Return(map[int]*substate.Substate{
+			0: input0,
+		}, nil),
+		src.EXPECT().GetBlockSubstates(uint64(2)).Return(map[int]*substate.Substate{
+			0: input0,
+		}, nil),
+	)
+
+	dst.EXPECT().PutSubstate(input0).Return(nil)
+	dst.EXPECT().PutSubstate(input0).Return(nil)
+	dst.EXPECT().PutSubstate(input0).Return(mockErr)
+	err := command.execute()
+
+	expected := fmt.Errorf("rlp-to-protobuf: 2_0: %w", fmt.Errorf("failed to put substate: %w", mockErr))
+	assert.Equal(t, expected, err)
+}
+
+func TestRLPtoProtobufCommand_ExecuteSuccessful(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	src := db.NewMockSubstateDB(ctrl)
+	dst := db.NewMockSubstateDB(ctrl)
+
+	set := flag.NewFlagSet("test", 0)
+	_ = set.String(BlockSegmentFlag.Name, "0-2", "")
+	_ = set.String(WorkersFlag.Name, "1", "")
+	ctx := cli.NewContext(&cli.App{}, set, nil)
+
+	command := rlpToProtobufCommand{
+		src: src,
+		dst: dst,
+		ctx: ctx,
+	}
+
+	input0 := &substate.Substate{
+		InputSubstate:  substate.NewWorldState(),
+		OutputSubstate: substate.NewWorldState(),
+		Env: &substate.Env{
+			Coinbase:   types.Address{1},
+			Difficulty: new(big.Int).SetUint64(1),
+			GasLimit:   1,
+			Number:     1,
+			Timestamp:  1,
+			BaseFee:    new(big.Int).SetUint64(1),
+		},
+		Message: substate.NewMessage(
+			1,
+			true,
+			new(big.Int).SetUint64(1),
+			1, types.Address{1},
+			new(types.Address),
+			new(big.Int).SetUint64(1),
+			[]byte{1},
+			nil,
+			new(int32),
+			types.AccessList{},
+			new(big.Int).SetUint64(1),
+			new(big.Int).SetUint64(1),
+			new(big.Int).SetUint64(1),
+			make([]types.Hash, 0),
+		),
+		Result:      substate.NewResult(1, types.Bloom{}, []*types.Log{}, types.Address{}, 1),
+		Block:       37_534_834,
+		Transaction: 1,
+	}
+
+	dst.EXPECT().SetSubstateEncoding("protobuf").Return(nil)
+	gomock.InOrder(
+		src.EXPECT().GetBlockSubstates(uint64(0)).Return(map[int]*substate.Substate{
+			0: input0,
+		}, nil),
+		src.EXPECT().GetBlockSubstates(uint64(1)).Return(map[int]*substate.Substate{
+			0: input0,
+		}, nil),
+		src.EXPECT().GetBlockSubstates(uint64(2)).Return(map[int]*substate.Substate{
+			0: input0,
+		}, nil),
+	)
+
+	dst.EXPECT().PutSubstate(input0).Return(nil).Times(3)
+
+	err := command.execute()
+	assert.Nil(t, err)
+}
+
+func TestRLPtoProtobufCommand_ExecuteParallelSuccessful(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	src := db.NewMockSubstateDB(ctrl)
+	dst := db.NewMockSubstateDB(ctrl)
+
+	set := flag.NewFlagSet("test", 0)
+	_ = set.String(BlockSegmentFlag.Name, "0-2", "")
+	_ = set.String(WorkersFlag.Name, "4", "")
+	ctx := cli.NewContext(&cli.App{}, set, nil)
+
+	command := rlpToProtobufCommand{
+		src: src,
+		dst: dst,
+		ctx: ctx,
+	}
+
+	input0 := &substate.Substate{
+		InputSubstate:  substate.NewWorldState(),
+		OutputSubstate: substate.NewWorldState(),
+		Env: &substate.Env{
+			Coinbase:   types.Address{1},
+			Difficulty: new(big.Int).SetUint64(1),
+			GasLimit:   1,
+			Number:     1,
+			Timestamp:  1,
+			BaseFee:    new(big.Int).SetUint64(1),
+		},
+		Message: substate.NewMessage(
+			1,
+			true,
+			new(big.Int).SetUint64(1),
+			1,
+			types.Address{1},
+			new(types.Address),
+			new(big.Int).SetUint64(1),
+			[]byte{1},
+			nil,
+			new(int32),
+			types.AccessList{},
+			new(big.Int).SetUint64(1),
+			new(big.Int).SetUint64(1),
+			new(big.Int).SetUint64(1),
+			make([]types.Hash, 0),
+		),
+		Result:      substate.NewResult(1, types.Bloom{}, []*types.Log{}, types.Address{}, 1),
+		Block:       37_534_834,
+		Transaction: 1,
+	}
+
+	dst.EXPECT().SetSubstateEncoding("protobuf").Return(nil)
+
+	src.EXPECT().GetBlockSubstates(uint64(0)).Return(map[int]*substate.Substate{
+		0: input0,
+	}, nil)
+	src.EXPECT().GetBlockSubstates(uint64(1)).Return(map[int]*substate.Substate{
+		0: input0,
+	}, nil)
+	src.EXPECT().GetBlockSubstates(uint64(2)).Return(map[int]*substate.Substate{
+		0: input0,
+	}, nil)
+
+	dst.EXPECT().PutSubstate(input0).Return(nil).Times(3)
+
+	err := command.execute()
+	assert.Nil(t, err)
+}
+
+func TestRLPtoProtobufCommand_ExecuteFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	src := db.NewMockSubstateDB(ctrl)
+	dst := db.NewMockSubstateDB(ctrl)
+
+	set := flag.NewFlagSet("test", 0)
+	_ = set.String(BlockSegmentFlag.Name, "0-2", "")
+	_ = set.String(WorkersFlag.Name, "1", "")
+	ctx := cli.NewContext(&cli.App{}, set, nil)
+	mockErr := errors.New("error")
+
+	command := rlpToProtobufCommand{
+		src: src,
+		dst: dst,
+		ctx: ctx,
+	}
+
+	input0 := &substate.Substate{
+		InputSubstate:  substate.NewWorldState(),
+		OutputSubstate: substate.NewWorldState(),
+		Env: &substate.Env{
+			Coinbase:   types.Address{1},
+			Difficulty: new(big.Int).SetUint64(1),
+			GasLimit:   1,
+			Number:     1,
+			Timestamp:  1,
+			BaseFee:    new(big.Int).SetUint64(1),
+		},
+		Message: substate.NewMessage(
+			1,
+			true,
+			new(big.Int).SetUint64(1),
+			1,
+			types.Address{1},
+			new(types.Address),
+			new(big.Int).SetUint64(1),
+			[]byte{1},
+			nil,
+			new(int32),
+			types.AccessList{},
+			new(big.Int).SetUint64(1),
+			new(big.Int).SetUint64(1),
+			new(big.Int).SetUint64(1),
+			make([]types.Hash, 0),
+		),
+		Result:      substate.NewResult(1, types.Bloom{}, []*types.Log{}, types.Address{}, 1),
+		Block:       37_534_834,
+		Transaction: 1,
+	}
+
+	dst.EXPECT().SetSubstateEncoding("protobuf").Return(nil)
+	gomock.InOrder(
+		src.EXPECT().GetBlockSubstates(uint64(0)).Return(map[int]*substate.Substate{
+			0: input0,
+		}, nil),
+		src.EXPECT().GetBlockSubstates(uint64(1)).Return(nil, mockErr),
+		src.EXPECT().GetBlockSubstates(uint64(2)).Return(map[int]*substate.Substate{
+			0: input0,
+		}, nil),
+	)
+
+	dst.EXPECT().PutSubstate(input0).Return(nil).Times(2)
+
+	err := command.execute()
+	assert.Equal(t, mockErr, err)
+}
+
+func TestRLPtoProtobufCommand_ExecuteParallelFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	src := db.NewMockSubstateDB(ctrl)
+	dst := db.NewMockSubstateDB(ctrl)
+
+	set := flag.NewFlagSet("test", 0)
+	_ = set.String(BlockSegmentFlag.Name, "0-2", "")
+	_ = set.String(WorkersFlag.Name, "4", "")
+	ctx := cli.NewContext(&cli.App{}, set, nil)
+	mockErr := errors.New("error")
+
+	command := rlpToProtobufCommand{
+		src: src,
+		dst: dst,
+		ctx: ctx,
+	}
+
+	input0 := &substate.Substate{
+		InputSubstate:  substate.NewWorldState(),
+		OutputSubstate: substate.NewWorldState(),
+		Env: &substate.Env{
+			Coinbase:   types.Address{1},
+			Difficulty: new(big.Int).SetUint64(1),
+			GasLimit:   1,
+			Number:     1,
+			Timestamp:  1,
+			BaseFee:    new(big.Int).SetUint64(1),
+		},
+		Message: substate.NewMessage(
+			1,
+			true,
+			new(big.Int).SetUint64(1),
+			1,
+			types.Address{1},
+			new(types.Address),
+			new(big.Int).SetUint64(1),
+			[]byte{1},
+			nil,
+			new(int32),
+			types.AccessList{},
+			new(big.Int).SetUint64(1),
+			new(big.Int).SetUint64(1),
+			new(big.Int).SetUint64(1),
+			make([]types.Hash, 0),
+		),
+		Result:      substate.NewResult(1, types.Bloom{}, []*types.Log{}, types.Address{}, 1),
+		Block:       37_534_834,
+		Transaction: 1,
+	}
+
+	dst.EXPECT().SetSubstateEncoding("protobuf").Return(nil)
+
+	src.EXPECT().GetBlockSubstates(uint64(0)).Return(map[int]*substate.Substate{
+		0: input0,
+	}, nil)
+	src.EXPECT().GetBlockSubstates(uint64(1)).Return(nil, mockErr)
+	src.EXPECT().GetBlockSubstates(uint64(2)).Return(map[int]*substate.Substate{
+		0: input0,
+	}, nil)
+
+	dst.EXPECT().PutSubstate(input0).Return(nil).Times(2)
+
+	err := command.execute()
+	assert.Equal(t, mockErr, err)
+}

--- a/cmd/rlp-to-protobuf/utils.go
+++ b/cmd/rlp-to-protobuf/utils.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type blockSegment struct {
+	First, Last uint64
+}
+
+func newBlockSegment(first, last uint64) *blockSegment {
+	return &blockSegment{
+		First: first,
+		Last:  last,
+	}
+}
+
+// parseBlockSegment parses a string representation of a block segment into a blockSegment struct.
+// The string can be in the format "first" or "first-last" with optional SI units (k for 1000, M for 1000000).
+// If the last block number is not provided, it is assumed to be the same as the first block number.
+//
+// Parameters:
+// - s: The string representation of the block segment.
+//
+// Returns:
+// - A pointer to a blockSegment struct with the parsed first and last block numbers.
+// - An error if the string is not in a valid format or if the block numbers are invalid.
+func parseBlockSegment(s string) (*blockSegment, error) {
+	var err error
+	// <first>: first block number
+	// <last>: optional, last block number
+	// <siunit>: optinal, k for 1000, M for 1000000
+	re := regexp.MustCompile(`^(?P<first>[0-9][0-9_]*)((-|~)(?P<last>[0-9][0-9_]*)(?P<siunit>[kM]?))?$`)
+	seg := &blockSegment{}
+	if !re.MatchString(s) {
+		return nil, fmt.Errorf("invalid block segment string: %q", s)
+	}
+	matches := re.FindStringSubmatch(s)
+	first := strings.ReplaceAll(matches[re.SubexpIndex("first")], "_", "")
+	seg.First, err = strconv.ParseUint(first, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid block segment first: %s", err)
+	}
+	last := strings.ReplaceAll(matches[re.SubexpIndex("last")], "_", "")
+	if len(last) == 0 {
+		seg.Last = seg.First
+	} else {
+		seg.Last, err = strconv.ParseUint(last, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid block segment last: %s", err)
+		}
+	}
+	siunit := matches[re.SubexpIndex("siunit")]
+	switch siunit {
+	case "k":
+		seg.First = seg.First*1_000 + 1
+		seg.Last = seg.Last * 1_000
+	case "M":
+		seg.First = seg.First*1_000_000 + 1
+		seg.Last = seg.Last * 1_000_000
+	}
+	if seg.First > seg.Last {
+		return nil, fmt.Errorf("block segment first is larger than last: %v-%v", seg.First, seg.Last)
+	}
+	return seg, nil
+}

--- a/cmd/rlp-to-protobuf/utils_test.go
+++ b/cmd/rlp-to-protobuf/utils_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseBlockSegment(t *testing.T) {
+	// success cases
+	mapInputOutput := map[string]*blockSegment{
+		"1":     newBlockSegment(1, 1),
+		"0-1M":  newBlockSegment(1, 1000000),
+		"1-200": newBlockSegment(1, 200),
+		"0-1k":  newBlockSegment(1, 1000),
+	}
+
+	for input, expected := range mapInputOutput {
+		value, err := parseBlockSegment(input)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, value)
+	}
+
+	// error cases
+	mapInputOutputError := map[string]string{
+		"1-0":                      "block segment first is larger than last: 1-0",
+		"1M":                       "invalid block segment string: \"1M\"",
+		"1-1M":                     "block segment first is larger than last: 1000001-1000000",
+		"1-100000000000000000000M": "invalid block segment last: strconv.ParseUint: parsing \"100000000000000000000\": value out of range",
+		"900000000000000000000-900000000000000000000M": "invalid block segment first: strconv.ParseUint: parsing \"900000000000000000000\": value out of range",
+	}
+	for input, expected := range mapInputOutputError {
+		value, err := parseBlockSegment(input)
+		assert.Nil(t, value)
+		assert.Equal(t, expected, err.Error())
+	}
+}


### PR DESCRIPTION
## Description

Add a command to convert the existing RLP-encoded substate database into Protobuf format.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

