### PR TITLE
Ensure error forwarding when raw data state closes before others

### DIFF
--- a/db/substate_db.go
+++ b/db/substate_db.go
@@ -49,6 +49,9 @@ type SubstateDB interface {
 
 	// GetSubstateEncoding returns the currently configured encoding
 	GetSubstateEncoding() string
+
+	// decodeSubstate defensively defaults to "default" if nil
+	decodeToSubstate(bytes []byte, block uint64, tx int) (*substate.Substate, error)
 }
 
 // NewDefaultSubstateDB creates new instance of SubstateDB with default options.

--- a/db/substate_db_mock.go
+++ b/db/substate_db_mock.go
@@ -389,6 +389,21 @@ func (mr *MockSubstateDBMockRecorder) Stat(property any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockSubstateDB)(nil).Stat), property)
 }
 
+// decodeToSubstate mocks base method.
+func (m *MockSubstateDB) decodeToSubstate(bytes []byte, block uint64, tx int) (*substate.Substate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "decodeToSubstate", bytes, block, tx)
+	ret0, _ := ret[0].(*substate.Substate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// decodeToSubstate indicates an expected call of decodeToSubstate.
+func (mr *MockSubstateDBMockRecorder) decodeToSubstate(bytes, block, tx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "decodeToSubstate", reflect.TypeOf((*MockSubstateDB)(nil).decodeToSubstate), bytes, block, tx)
+}
+
 // getBackend mocks base method.
 func (m *MockSubstateDB) getBackend() *leveldb.DB {
 	m.ctrl.T.Helper()

--- a/db/substate_iterator_test.go
+++ b/db/substate_iterator_test.go
@@ -1,8 +1,17 @@
 package db
 
 import (
+	"encoding/binary"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/0xsoniclabs/substate/substate"
+	"github.com/stretchr/testify/assert"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/testutil"
+	"go.uber.org/mock/gomock"
 )
 
 func TestSubstateIterator_Next(t *testing.T) {
@@ -134,4 +143,412 @@ func TestSubstateIterator_FromBlock(t *testing.T) {
 	if ss2.Transaction != 1 {
 		t.Fatalf("iterator returned transaction with different transaction number\ngot: %v\n want: %v", ss2.Transaction, 1)
 	}
+}
+
+func TestSubstateIterator_DecodeSuccess(t *testing.T) {
+	// given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDb := NewMockSubstateDB(ctrl)
+	start := 10
+	blockTx := make([]byte, 8)
+	binary.BigEndian.PutUint64(blockTx, uint64(start))
+	kv := testutil.KeyValue_Generate(nil, 70, 1, 1, 5, 3, 3)
+	mockIterator := iterator.NewArrayIterator(kv)
+	expected := &substate.Substate{}
+
+	mockDb.EXPECT().NewIterator([]byte(SubstateDBPrefix), blockTx).Return(mockIterator)
+	mockDb.EXPECT().decodeToSubstate(gomock.Any(), gomock.Any(), gomock.Any()).Return(expected, nil)
+
+	// when
+	substateIterator := newSubstateIterator(mockDb, blockTx)
+	actual, err := substateIterator.decode(rawEntry{
+		key:   []byte(SubstateDBPrefix + "3456789123456789"),
+		value: []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+	)
+
+	// then
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestSubstateIterator_DecodeFail(t *testing.T) {
+	// given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDb := NewMockSubstateDB(ctrl)
+	start := 10
+	blockTx := make([]byte, 8)
+	binary.BigEndian.PutUint64(blockTx, uint64(start))
+	kv := testutil.KeyValue_Generate(nil, 70, 1, 1, 5, 3, 3)
+	mockIterator := iterator.NewArrayIterator(kv)
+
+	mockDb.EXPECT().NewIterator([]byte(SubstateDBPrefix), blockTx).Return(mockIterator)
+
+	// when
+	substateIterator := newSubstateIterator(mockDb, blockTx)
+	actual, err := substateIterator.decode(rawEntry{
+		key:   []byte(SubstateDBPrefix),
+		value: []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+	)
+
+	// then
+	assert.NotNil(t, err)
+	assert.Nil(t, actual)
+}
+
+func TestSubstateIterator_StartFailReading(t *testing.T) {
+	// given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDb := NewMockSubstateDB(ctrl)
+	start := 10
+	blockTx := make([]byte, 8)
+	binary.BigEndian.PutUint64(blockTx, uint64(start))
+	kv := &testutil.KeyValue{}
+	kv.PutU([]byte(SubstateDBPrefix+"1234567890123456"), []byte("a"))
+	kv.PutU([]byte(SubstateDBPrefix+"1234567890123457error"), []byte("b"))
+	mockIterator := iterator.NewArrayIterator(kv)
+	mockSubstate := getTestSubstate("protobuf")
+
+	mockDb.EXPECT().NewIterator([]byte(SubstateDBPrefix), blockTx).Return(mockIterator)
+	mockDb.EXPECT().decodeToSubstate(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubstate, nil)
+
+	// when
+	count := 0
+	iter := newSubstateIterator(mockDb, blockTx)
+	iter.start(1)
+	for iter.Next() {
+		tx := iter.Value()
+		assert.Equal(t, mockSubstate, tx)
+		count += 1
+	}
+	iter.Release()
+	err := iter.Error()
+
+	// then
+	assert.NotNil(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestSubstateIterator_StartFailDecoding(t *testing.T) {
+	// given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDb := NewMockSubstateDB(ctrl)
+	start := 10
+	blockTx := make([]byte, 8)
+	binary.BigEndian.PutUint64(blockTx, uint64(start))
+	kv := &testutil.KeyValue{}
+	kv.PutU([]byte(SubstateDBPrefix+"1234567890123456"), []byte("a"))
+	kv.PutU([]byte(SubstateDBPrefix+"1234567890123457"), []byte("b"))
+	mockIterator := iterator.NewArrayIterator(kv)
+	mockSubstate := getTestSubstate("protobuf")
+	mockError := errors.New("error")
+	mockDb.EXPECT().NewIterator([]byte(SubstateDBPrefix), blockTx).Return(mockIterator)
+	gomock.InOrder(
+		mockDb.EXPECT().decodeToSubstate(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubstate, nil),
+		mockDb.EXPECT().decodeToSubstate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mockError),
+	)
+
+	var expectedValues = []*substate.Substate{mockSubstate, nil}
+
+	// when
+	count := 0
+	iter := newSubstateIterator(mockDb, blockTx)
+	iter.start(1)
+	for iter.Next() {
+		tx := iter.Value()
+		assert.Equal(t, expectedValues[count], tx)
+		count += 1
+	}
+	iter.Release()
+	err := iter.Error()
+
+	// then
+	assert.NotNil(t, err)
+	assert.Equal(t, mockError.Error(), err.Error())
+	assert.Equal(t, 1, count)
+}
+
+func TestSubstateIterator_StartReaderStopFirstSuccess(t *testing.T) {
+	// given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDb := NewMockSubstateDB(ctrl)
+	start := 10
+	blockTx := make([]byte, 8)
+	binary.BigEndian.PutUint64(blockTx, uint64(start))
+	kv := &testutil.KeyValue{}
+	kv.PutU([]byte(SubstateDBPrefix+"1234567890123456"), []byte("a"))
+	kv.PutU([]byte(SubstateDBPrefix+"1234567890123457"), []byte("b"))
+	mockIterator := iterator.NewArrayIterator(MockKeyValue{kv, 10 * time.Millisecond})
+	mockSubstate := getTestSubstate("protobuf")
+
+	mockDb.EXPECT().NewIterator([]byte(SubstateDBPrefix), blockTx).Return(mockIterator)
+	mockDb.EXPECT().decodeToSubstate(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(a, b, c interface{}) {
+		time.Sleep(10 * time.Millisecond)
+	}).Return(mockSubstate, nil).Times(2)
+
+	// when
+	count := 0
+	iter := newSubstateIterator(mockDb, blockTx)
+	iter.start(1)
+	for iter.Next() {
+		tx := iter.Value()
+		assert.Equal(t, mockSubstate, tx)
+		count += 1
+		time.Sleep(10 * time.Millisecond)
+	}
+	iter.Release()
+	err := iter.Error()
+
+	// then
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestSubstateIterator_StartDecoderStopFirstSuccess(t *testing.T) {
+	// given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDb := NewMockSubstateDB(ctrl)
+	start := 10
+	blockTx := make([]byte, 8)
+	binary.BigEndian.PutUint64(blockTx, uint64(start))
+	kv := &testutil.KeyValue{}
+	for i := 0; i < 100; i++ {
+		var id = uint64(1234567890123450)
+		var key = fmt.Sprintf("%v%v", SubstateDBPrefix, id+uint64(i))
+		var value = fmt.Sprintf("input%v", i)
+		kv.PutU([]byte(key), []byte(value))
+	}
+	mockIterator := iterator.NewArrayIterator(MockKeyValue{kv, 10 * time.Millisecond})
+	mockSubstate := getTestSubstate("protobuf")
+
+	mockDb.EXPECT().NewIterator([]byte(SubstateDBPrefix), blockTx).Return(mockIterator)
+	mockDb.EXPECT().decodeToSubstate(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubstate, nil).MinTimes(50)
+
+	// when
+	count := 0
+	iter := newSubstateIterator(mockDb, blockTx)
+	iter.start(1)
+	for iter.Next() {
+		tx := iter.Value()
+		assert.Equal(t, mockSubstate, tx)
+		count += 1
+		if count == 50 {
+			break
+		}
+	}
+	iter.Release()
+	err := iter.Error()
+
+	// then
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 50, count)
+}
+
+func TestSubstateIterator_StartParallelSuccess(t *testing.T) {
+	// given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDb := NewMockSubstateDB(ctrl)
+	start := 10
+	blockTx := make([]byte, 8)
+	binary.BigEndian.PutUint64(blockTx, uint64(start))
+	kv := &testutil.KeyValue{}
+	for i := 0; i < 100; i++ {
+		var id = uint64(1234567890123450)
+		var key = fmt.Sprintf("%v%v", SubstateDBPrefix, id+uint64(i))
+		var value = fmt.Sprintf("input%v", i)
+		kv.PutU([]byte(key), []byte(value))
+	}
+	mockIterator := iterator.NewArrayIterator(MockKeyValue{kv, 10 * time.Millisecond})
+	mockSubstate := getTestSubstate("protobuf")
+
+	mockDb.EXPECT().NewIterator([]byte(SubstateDBPrefix), blockTx).Return(mockIterator)
+	mockDb.EXPECT().decodeToSubstate(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubstate, nil).Times(100)
+
+	// when
+	count := 0
+	iter := newSubstateIterator(mockDb, blockTx)
+	iter.start(10)
+	for iter.Next() {
+		tx := iter.Value()
+		assert.Equal(t, mockSubstate, tx)
+		count += 1
+	}
+	iter.Release()
+	err := iter.Error()
+
+	// then
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 100, count)
+}
+
+func TestSubstateIterator_StartParallelFail(t *testing.T) {
+	// given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDb := NewMockSubstateDB(ctrl)
+	start := 10
+	blockTx := make([]byte, 8)
+	binary.BigEndian.PutUint64(blockTx, uint64(start))
+	kv := &testutil.KeyValue{}
+	for i := 0; i < 100; i++ {
+		var id = uint64(1234567890123450)
+		var key = fmt.Sprintf("%v%v", SubstateDBPrefix, id+uint64(i))
+		var value = fmt.Sprintf("input%v", i)
+		kv.PutU([]byte(key), []byte(value))
+	}
+	mockIterator := iterator.NewArrayIterator(MockKeyValue{kv, 10 * time.Millisecond})
+	mockSubstate := getTestSubstate("protobuf")
+	mockError := errors.New("error")
+
+	mockDb.EXPECT().NewIterator([]byte(SubstateDBPrefix), blockTx).Return(mockIterator)
+	gomock.InOrder(
+		mockDb.EXPECT().decodeToSubstate(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubstate, nil).Times(99),
+		mockDb.EXPECT().decodeToSubstate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mockError).Times(1),
+	)
+
+	// when
+	count := 0
+	iter := newSubstateIterator(mockDb, blockTx)
+	iter.start(10)
+	for iter.Next() {
+		tx := iter.Value()
+		assert.Equal(t, mockSubstate, tx)
+		count += 1
+	}
+	iter.Release()
+	err := iter.Error()
+
+	// then
+	assert.NotNil(t, err)
+	assert.Equal(t, mockError.Error(), err.Error())
+	assert.True(t, count < 100)
+}
+
+func TestSubstateIterator_StartParallelReaderStopFirstFail(t *testing.T) {
+	// given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDb := NewMockSubstateDB(ctrl)
+	start := 10
+	blockTx := make([]byte, 8)
+	binary.BigEndian.PutUint64(blockTx, uint64(start))
+	kv := &testutil.KeyValue{}
+	for i := 0; i < 100; i++ {
+		var id = uint64(1234567890123450)
+		var key = fmt.Sprintf("%v%v", SubstateDBPrefix, id+uint64(i))
+		var value = fmt.Sprintf("input%v", i)
+		kv.PutU([]byte(key), []byte(value))
+	}
+	mockIterator := iterator.NewArrayIterator(MockKeyValue{kv, 10 * time.Millisecond})
+	mockSubstate := getTestSubstate("protobuf")
+	mockError := errors.New("error")
+
+	mockDb.EXPECT().NewIterator([]byte(SubstateDBPrefix), blockTx).Return(mockIterator)
+	gomock.InOrder(
+		mockDb.EXPECT().decodeToSubstate(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(a, b, c interface{}) {
+			time.Sleep(10 * time.Millisecond)
+		}).Return(mockSubstate, nil).Times(99),
+		mockDb.EXPECT().decodeToSubstate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mockError).Times(1),
+	)
+
+	// when
+	count := 0
+	iter := newSubstateIterator(mockDb, blockTx)
+	iter.start(10)
+	for iter.Next() {
+		tx := iter.Value()
+		assert.Equal(t, mockSubstate, tx)
+		count += 1
+		time.Sleep(10 * time.Millisecond)
+	}
+	iter.Release()
+	err := iter.Error()
+
+	// then
+	assert.NotNil(t, err)
+	assert.Equal(t, mockError.Error(), err.Error())
+	assert.True(t, count < 100)
+}
+
+func TestSubstateIterator_StartParallelDecoderStopFirstFail(t *testing.T) {
+	// given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDb := NewMockSubstateDB(ctrl)
+	start := 10
+	blockTx := make([]byte, 8)
+	binary.BigEndian.PutUint64(blockTx, uint64(start))
+	kv := &testutil.KeyValue{}
+	for i := 0; i < 100; i++ {
+		var id = uint64(1234567890123450)
+		var key = fmt.Sprintf("%v%v", SubstateDBPrefix, id+uint64(i))
+		var value = fmt.Sprintf("input%v", i)
+		kv.PutU([]byte(key), []byte(value))
+	}
+	mockIterator := iterator.NewArrayIterator(MockKeyValue{kv, 10 * time.Millisecond})
+	mockSubstate := getTestSubstate("protobuf")
+	mockError := errors.New("error")
+
+	mockDb.EXPECT().NewIterator([]byte(SubstateDBPrefix), blockTx).Return(mockIterator)
+	gomock.InOrder(
+		mockDb.EXPECT().decodeToSubstate(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubstate, nil).Times(49),
+		mockDb.EXPECT().decodeToSubstate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mockError).Times(1),
+		mockDb.EXPECT().decodeToSubstate(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubstate, nil).AnyTimes(),
+	)
+
+	// when
+	count := 0
+	iter := newSubstateIterator(mockDb, blockTx)
+	iter.start(10)
+	for iter.Next() {
+		tx := iter.Value()
+		assert.Equal(t, mockSubstate, tx)
+		count += 1
+		if count == 50 {
+			break
+		}
+	}
+	iter.Release()
+	err := iter.Error()
+
+	// then
+	assert.NotNil(t, err)
+	assert.Equal(t, mockError.Error(), err.Error())
+	assert.True(t, count < 50)
+}
+
+type MockKeyValue struct {
+	kv    *testutil.KeyValue
+	delay time.Duration
+}
+
+func (kv MockKeyValue) Len() int {
+	return kv.kv.Len()
+}
+
+func (kv MockKeyValue) Search(key []byte) int {
+	return kv.kv.Search(key)
+}
+
+func (kv MockKeyValue) Index(i int) (key, value []byte) {
+	if kv.delay > 0 {
+		time.Sleep(kv.delay)
+	}
+	return kv.kv.Index(i)
 }

--- a/go.mod
+++ b/go.mod
@@ -17,10 +17,19 @@ require (
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
+	github.com/nxadm/tail v1.4.4 // indirect
+	github.com/onsi/ginkgo v1.14.0 // indirect
+	github.com/onsi/gomega v1.10.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
+	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
## Description

Sometimes, the raw data stage closes before other go-routines, which can cause errors to be missed, such as in short-range iterations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
