### PR TITLE
Refactor SetSubstateEncoding to return error only

### DIFF
--- a/db/substate_db.go
+++ b/db/substate_db.go
@@ -45,7 +45,7 @@ type SubstateDB interface {
 	GetLastSubstate() (*substate.Substate, error)
 
 	// SetSubstateEncoding sets the decoder func to the provided encoding
-	SetSubstateEncoding(encoding string) (*substateDB, error)
+	SetSubstateEncoding(encoding string) error
 
 	// GetSubstateEncoding returns the currently configured encoding
 	GetSubstateEncoding() string
@@ -64,13 +64,13 @@ func NewSubstateDB(path string, o *opt.Options, wo *opt.WriteOptions, ro *opt.Re
 
 func MakeDefaultSubstateDB(db *leveldb.DB) SubstateDB {
 	sdb := &substateDB{&codeDB{&baseDB{backend: db}}, nil}
-	sdb, _ = sdb.SetSubstateEncoding("default")
+	sdb.SetSubstateEncoding("default")
 	return sdb
 }
 
 func MakeDefaultSubstateDBFromBaseDB(db BaseDB) SubstateDB {
 	sdb := &substateDB{&codeDB{&baseDB{backend: db.getBackend()}}, nil}
-	sdb, _ = sdb.SetSubstateEncoding("default")
+	sdb.SetSubstateEncoding("default")
 	return sdb
 }
 
@@ -81,7 +81,7 @@ func NewReadOnlySubstateDB(path string) (SubstateDB, error) {
 
 func MakeSubstateDB(db *leveldb.DB, wo *opt.WriteOptions, ro *opt.ReadOptions) SubstateDB {
 	sdb := &substateDB{&codeDB{&baseDB{backend: db, wo: wo, ro: ro}}, nil}
-	sdb, _ = sdb.SetSubstateEncoding("default")
+	sdb.SetSubstateEncoding("default")
 	return sdb
 }
 
@@ -92,7 +92,7 @@ func newSubstateDB(path string, o *opt.Options, wo *opt.WriteOptions, ro *opt.Re
 	}
 
 	sdb := &substateDB{base, nil}
-	sdb, _ = sdb.SetSubstateEncoding("default")
+	sdb.SetSubstateEncoding("default")
 	return sdb, nil
 }
 

--- a/db/substate_db_mock.go
+++ b/db/substate_db_mock.go
@@ -361,12 +361,11 @@ func (mr *MockSubstateDBMockRecorder) PutSubstate(substate any) *gomock.Call {
 }
 
 // SetSubstateEncoding mocks base method.
-func (m *MockSubstateDB) SetSubstateEncoding(encoding string) (*substateDB, error) {
+func (m *MockSubstateDB) SetSubstateEncoding(encoding string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetSubstateEncoding", encoding)
-	ret0, _ := ret[0].(*substateDB)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // SetSubstateEncoding indicates an expected call of SetSubstateEncoding.

--- a/db/substate_encoding.go
+++ b/db/substate_encoding.go
@@ -15,16 +15,16 @@ import (
 // intended usage:
 //
 //	db := &substateDB{..} // default to rlp
-//	     db, err := db.SetSubstateEncoding(<schema>) // set encoding
+//	     err := db.SetSubstateEncoding(<schema>) // set encoding
 //	     db.GetSubstateDecoder() // returns configured encoding
-func (db *substateDB) SetSubstateEncoding(schema string) (*substateDB, error) {
+func (db *substateDB) SetSubstateEncoding(schema string) error {
 	encoding, err := newSubstateEncoding(schema, db.GetCode)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set decoder; %w", err)
+		return fmt.Errorf("failed to set decoder; %w", err)
 	}
 
 	db.encoding = encoding
-	return db, nil
+	return nil
 }
 
 // GetDecoder returns the encoding in use

--- a/db/substate_encoding_test.go
+++ b/db/substate_encoding_test.go
@@ -60,7 +60,7 @@ func TestSubstateEncoding_DefaultEncodingDefaultsToRlp(t *testing.T) {
 			t.Errorf("cannot open db; %v", err)
 		}
 
-		_, err = db.SetSubstateEncoding(defaultEncoding)
+		err = db.SetSubstateEncoding(defaultEncoding)
 		if err != nil {
 			t.Fatalf("Default encoding '%s' must be supported, but error", defaultEncoding)
 		}
@@ -83,7 +83,7 @@ func TestSubstateEncoding_UnsupportedEncodingThrowsError(t *testing.T) {
 		t.Errorf("cannot open db; %v", err)
 	}
 
-	_, err = db.SetSubstateEncoding("EncodingNotSupported")
+	err = db.SetSubstateEncoding("EncodingNotSupported")
 	if err == nil || !strings.Contains(err.Error(), "encoding not supported") {
 		t.Error("encoding not supported, but no error")
 	}
@@ -98,7 +98,7 @@ func TestSubstateEncoding_TestDb(t *testing.T) {
 		}
 
 		ts := getTestSubstate(encoding)
-		db, err = db.SetSubstateEncoding(encoding)
+		err = db.SetSubstateEncoding(encoding)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -128,7 +128,7 @@ func TestSubstateEncoding_TestIterator(t *testing.T) {
 			t.Errorf("cannot open db; %v", err)
 		}
 
-		_, err = db.SetSubstateEncoding(encoding)
+		err = db.SetSubstateEncoding(encoding)
 		if err != nil {
 			t.Error(err)
 		}

--- a/protobuf/substate.pb.go
+++ b/protobuf/substate.pb.go
@@ -7,11 +7,12 @@
 package protobuf
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (


### PR DESCRIPTION
## Description

`SetSubstateEncoding` return `substateDB` (private struct) which is hard for unit testing. After discussion in #14 , substateDB will be removed from return value.

Fixes # (issue)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (changes that do NOT affect functionality)
