### PR TITLE
Refactor encoding functions to use BigIntToBytes to avoid panic

### DIFF
--- a/protobuf/encode.go
+++ b/protobuf/encode.go
@@ -69,7 +69,7 @@ func toProtobufBlockEnv(se *substate.Env) *Substate_BlockEnv {
 
 	return &Substate_BlockEnv{
 		Coinbase:    se.Coinbase.Bytes(),
-		Difficulty:  se.Difficulty.Bytes(),
+		Difficulty:  BigIntToBytes(se.Difficulty),
 		GasLimit:    &se.GasLimit,
 		Number:      &se.Number,
 		Timestamp:   &se.Timestamp,
@@ -106,11 +106,11 @@ func toProtobufTxMessage(sm *substate.Message) *Substate_TxMessage {
 
 	return &Substate_TxMessage{
 		Nonce:         &sm.Nonce,
-		GasPrice:      sm.GasPrice.Bytes(),
+		GasPrice:      BigIntToBytes(sm.GasPrice),
 		Gas:           &sm.Gas,
 		From:          sm.From.Bytes(),
 		To:            AddressToWrapperspbBytes(sm.To),
-		Value:         sm.Value.Bytes(),
+		Value:         BigIntToBytes(sm.Value),
 		Input:         txInput,
 		TxType:        &txType,
 		AccessList:    accessList,

--- a/protobuf/utils.go
+++ b/protobuf/utils.go
@@ -57,3 +57,10 @@ func BytesToBigInt(b []byte) *big.Int {
 	}
 	return new(big.Int).SetBytes(b)
 }
+
+func BigIntToBytes(i *big.Int) []byte {
+	if i == nil {
+		return nil
+	}
+	return i.Bytes()
+}


### PR DESCRIPTION
## Description

Calling `.Bytes()` directly can cause panic, wrap it under `BigIntToBytes` to fix this problem

## Type of change

Please delete options that are not relevant.

- [x] Refactoring (changes that do NOT affect functionality)
