### PR TITLE
Ensuring code hashes are included in the substate representation

### DIFF
--- a/protobuf/encode.go
+++ b/protobuf/encode.go
@@ -11,7 +11,9 @@ import (
 
 // Encode converts aida-substate into protobuf-encoded message
 func Encode(ss *substate.Substate, block uint64, tx int) ([]byte, error) {
-	bytes, err := proto.Marshal(toProtobufSubstate(ss))
+	// Field `Account.contract.code_hash` and `TxMessage.input.init_code_hash` are required by the decoder
+	// We need to ensure that the code hashes are not nil by calling `HashedCopy` method
+	bytes, err := proto.Marshal(toProtobufSubstate(ss).HashedCopy())
 	if err != nil {
 		return nil, fmt.Errorf("cannot encode substate into protobuf block: %v,tx %v; %w", block, tx, err)
 	}

--- a/protobuf/utils.go
+++ b/protobuf/utils.go
@@ -3,6 +3,9 @@ package protobuf
 import (
 	"math/big"
 
+	"github.com/0xsoniclabs/substate/types/hash"
+	"google.golang.org/protobuf/proto"
+
 	"github.com/0xsoniclabs/substate/types"
 	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 )
@@ -63,4 +66,72 @@ func BigIntToBytes(i *big.Int) []byte {
 		return nil
 	}
 	return i.Bytes()
+}
+
+// CodeHash computes the Keccak256 hash of the given byte slice `code`.
+//
+// Parameters:
+// - code: A byte slice representing the code to be hashed.
+//
+// Returns:
+// - A types.Hash object containing the Keccak256 hash of the input code.
+func CodeHash(code []byte) types.Hash {
+	return hash.Keccak256Hash(code)
+}
+
+// HashToBytes converts a types.Hash object to a byte slice.
+//
+// Parameters:
+// - hash: A pointer to a types.Hash object to be converted.
+//
+// Returns:
+// - A byte slice representing the hash. If the input hash is nil, it returns nil.
+func HashToBytes(hash *types.Hash) []byte {
+	if hash == nil {
+		return nil
+	}
+	return hash.Bytes()
+}
+
+// HashedCopy creates a deep copy of the Substate object with code hashes instead of code bytes.
+//
+// Returns:
+// - A new Substate object with code hashes instead of code bytes.
+func (s *Substate) HashedCopy() *Substate {
+	y := proto.Clone(s).(*Substate)
+
+	if y == nil {
+		return nil
+	}
+
+	for _, entry := range y.InputAlloc.Alloc {
+		account := entry.Account
+		if code := account.GetCode(); code != nil {
+			codeHash := CodeHash(code)
+			account.Contract = &Substate_Account_CodeHash{
+				CodeHash: HashToBytes(&codeHash),
+			}
+		}
+	}
+
+	for _, entry := range y.OutputAlloc.Alloc {
+		account := entry.Account
+		if code := account.GetCode(); code != nil {
+			codeHash := CodeHash(code)
+			account.Contract = &Substate_Account_CodeHash{
+				CodeHash: HashToBytes(&codeHash),
+			}
+		}
+	}
+
+	if y.TxMessage.To == nil {
+		if code := y.TxMessage.GetData(); code != nil {
+			codeHash := CodeHash(code)
+			y.TxMessage.Input = &Substate_TxMessage_InitCodeHash{
+				InitCodeHash: HashToBytes(&codeHash),
+			}
+		}
+	}
+
+	return y
 }

--- a/protobuf/utils_test.go
+++ b/protobuf/utils_test.go
@@ -1,13 +1,48 @@
 package protobuf
 
 import (
+	"bytes"
 	"math/big"
 	"testing"
+
+	"github.com/0xsoniclabs/substate/types/hash"
 
 	"github.com/0xsoniclabs/substate/types"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
+
+// bytesPadding pads the input byte slice `data` with leading zeros to ensure it has the specified `length`.
+// If the length of `data` is already greater than or equal to `length`, it returns `data` unchanged.
+// Otherwise, it creates a new byte slice of the specified `length`, copies `data` into the end of the new slice,
+// and returns the new slice.
+//
+// Parameters:
+// - data: The input byte slice to be padded.
+// - length: The desired length of the output byte slice.
+//
+// Returns:
+// - A new byte slice of the specified `length` with `data` copied into the end, padded with leading zeros if necessary.
+func bytesPadding(data []byte, length int) []byte {
+	if len(data) >= length {
+		return data
+	}
+	temp := make([]byte, length)
+	copy(temp[length-len(data):], data)
+	return temp
+}
+
+// codeHash computes the Keccak-256 hash of the given byte slice `data` and returns it as a pointer to a types.Hash.
+//
+// Parameters:
+// - data: The input byte slice to be hashed.
+//
+// Returns:
+// - A pointer to a types.Hash containing the Keccak-256 hash of the input data.
+func codeHash(data []byte) *types.Hash {
+	h := CodeHash(data)
+	return &h
+}
 
 func TestUtils_BytesValueToHashWithNilInput(t *testing.T) {
 	result := BytesValueToHash(nil)
@@ -98,4 +133,146 @@ func TestUtils_BigIntToBytesWithValidInput(t *testing.T) {
 	num := big.NewInt(256)
 	result := BigIntToBytes(num)
 	assert.Equal(t, num.Bytes(), result)
+}
+
+func TestBytesValueToHash(t *testing.T) {
+	bytesValue := &wrapperspb.BytesValue{Value: []byte{0x01, 0x02, 0x03, 0x04}}
+	expectedHash := types.BytesToHash([]byte{0x01, 0x02, 0x03, 0x04})
+	hash := BytesValueToHash(bytesValue)
+	assert.NotNil(t, hash)
+	assert.Equal(t, expectedHash, *hash)
+
+	hash = BytesValueToHash(nil)
+	assert.Nil(t, hash)
+}
+
+func TestBytesValueToBigInt(t *testing.T) {
+	bytesValue := &wrapperspb.BytesValue{Value: []byte{0x01, 0x02, 0x03, 0x04}}
+	expectedBigInt := new(big.Int).SetBytes([]byte{0x01, 0x02, 0x03, 0x04})
+	bigInt := BytesValueToBigInt(bytesValue)
+	assert.NotNil(t, bigInt)
+	assert.Equal(t, expectedBigInt, bigInt)
+
+	bigInt = BytesValueToBigInt(nil)
+	assert.Nil(t, bigInt)
+}
+
+func TestBytesValueToAddress(t *testing.T) {
+	bytesValue := &wrapperspb.BytesValue{Value: []byte{0x01, 0x02, 0x03, 0x04}}
+	expectedAddress := types.BytesToAddress([]byte{0x01, 0x02, 0x03, 0x04})
+	address := BytesValueToAddress(bytesValue)
+	assert.NotNil(t, address)
+	assert.Equal(t, expectedAddress, *address)
+
+	address = BytesValueToAddress(nil)
+	assert.Nil(t, address)
+}
+
+func TestAddressToWrapperspbBytes(t *testing.T) {
+	address := types.BytesToAddress([]byte{0x01, 0x02, 0x03, 0x04})
+	expectedBytesValue := bytesPadding([]byte{0x01, 0x02, 0x03, 0x04}, 20)
+	bytesValue := AddressToWrapperspbBytes(&address)
+	assert.NotNil(t, bytesValue)
+	assert.Equal(t, expectedBytesValue, bytesValue.GetValue())
+
+	bytesValue = AddressToWrapperspbBytes(nil)
+	assert.Nil(t, bytesValue)
+}
+
+func TestHashToWrapperspbBytes(t *testing.T) {
+	hash := types.BytesToHash([]byte{0x01, 0x02, 0x03, 0x04})
+	expectedBytesValue := bytesPadding([]byte{0x01, 0x02, 0x03, 0x04}, 32)
+	bytesValue := HashToWrapperspbBytes(&hash)
+	assert.NotNil(t, bytesValue)
+	assert.Equal(t, expectedBytesValue, bytesValue.GetValue())
+
+	bytesValue = HashToWrapperspbBytes(nil)
+	assert.Nil(t, bytesValue)
+}
+
+func TestBigIntToWrapperspbBytes(t *testing.T) {
+	bigInt := new(big.Int).SetBytes([]byte{0x01, 0x02, 0x03, 0x04})
+	expectedBytesValue := &wrapperspb.BytesValue{Value: []byte{0x01, 0x02, 0x03, 0x04}}
+	bytesValue := BigIntToWrapperspbBytes(bigInt)
+	assert.NotNil(t, bytesValue)
+	assert.True(t, bytes.Equal(bytesValue.GetValue(), expectedBytesValue.GetValue()))
+
+	bytesValue = BigIntToWrapperspbBytes(nil)
+	assert.Nil(t, bytesValue)
+}
+
+func TestBytesToBigInt(t *testing.T) {
+	bytes := []byte{0x01, 0x02, 0x03, 0x04}
+	expectedBigInt := new(big.Int).SetBytes(bytes)
+	bigInt := BytesToBigInt(bytes)
+	assert.NotNil(t, bigInt)
+	assert.Equal(t, expectedBigInt, bigInt)
+
+	bigInt = BytesToBigInt(nil)
+	assert.Nil(t, bigInt)
+}
+
+func TestCodeHash(t *testing.T) {
+	code := []byte{0x01, 0x02, 0x03, 0x04}
+	expected := hash.Keccak256Hash(code)
+	actual := CodeHash(code)
+	assert.Equal(t, expected, actual)
+
+	expected = hash.Keccak256Hash(nil)
+	actual = CodeHash(nil)
+	assert.Equal(t, expected, actual)
+}
+
+func TestHashToBytes(t *testing.T) {
+	hash := types.BytesToHash([]byte{0x01, 0x02, 0x03, 0x04})
+	expectedBytes := bytesPadding([]byte{0x1, 0x2, 0x3, 0x4}, 32)
+	actualBytes := HashToBytes(&hash)
+	assert.Equal(t, expectedBytes, actualBytes)
+
+	actualBytes = HashToBytes(nil)
+	assert.Nil(t, actualBytes)
+}
+
+func TestHashedCopy(t *testing.T) {
+	input := &Substate{
+		InputAlloc: &Substate_Alloc{
+			Alloc: []*Substate_AllocEntry{
+				{
+					Account: &Substate_Account{
+						Contract: &Substate_Account_Code{
+							Code: []byte{0x01, 0x02, 0x03, 0x04},
+						},
+					},
+				},
+			},
+		},
+		OutputAlloc: &Substate_Alloc{
+			Alloc: []*Substate_AllocEntry{
+				{
+					Account: &Substate_Account{
+						Contract: &Substate_Account_Code{
+							Code: []byte{0x02, 0x03, 0x04, 0x05},
+						},
+					},
+				},
+			},
+		},
+		TxMessage: &Substate_TxMessage{
+			Input: &Substate_TxMessage_Data{
+				Data: []byte{0x03, 0x04, 0x05, 0x06},
+			},
+		},
+	}
+	output := input.HashedCopy()
+	inputAllocAcc := output.GetInputAlloc().GetAlloc()[0].GetAccount().GetCodeHash()
+	outputAllocAcc := output.GetOutputAlloc().GetAlloc()[0].GetAccount().GetCodeHash()
+	txMessageInput := output.GetTxMessage().GetInitCodeHash()
+
+	assert.Equal(t, inputAllocAcc, HashToBytes(codeHash([]byte{0x01, 0x02, 0x03, 0x04})))
+	assert.Equal(t, outputAllocAcc, HashToBytes(codeHash([]byte{0x02, 0x03, 0x04, 0x05})))
+	assert.Equal(t, txMessageInput, HashToBytes(codeHash([]byte{0x03, 0x04, 0x05, 0x06})))
+
+	var nilSubstate *Substate
+	output = nilSubstate.HashedCopy()
+	assert.Nil(t, output)
 }


### PR DESCRIPTION
## Description

The current encoder implementation does not include 'code_hash' from the substate in the encoded protobuf output, which is required by the substate decoder.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
