### PR TITLE
Refactor account balance handling to use uint256 avoid redundant casting

### DIFF
--- a/db/substate_db_test.go
+++ b/db/substate_db_test.go
@@ -6,6 +6,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/holiman/uint256"
+
 	"github.com/0xsoniclabs/substate/protobuf"
 	"github.com/stretchr/testify/assert"
 	"github.com/syndtr/goleveldb/leveldb"
@@ -21,8 +23,8 @@ import (
 func getTestSubstate(encoding string) *substate.Substate {
 	txType := int32(substate.AccessListTxType)
 	ss := &substate.Substate{
-		InputSubstate:  substate.NewWorldState().Add(types.Address{1}, 1, new(big.Int).SetUint64(1), nil),
-		OutputSubstate: substate.NewWorldState().Add(types.Address{2}, 2, new(big.Int).SetUint64(2), nil),
+		InputSubstate:  substate.NewWorldState().Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), nil),
+		OutputSubstate: substate.NewWorldState().Add(types.Address{2}, 2, new(uint256.Int).SetUint64(2), nil),
 		Env: &substate.Env{
 			Coinbase:   types.Address{1},
 			Difficulty: new(big.Int).SetUint64(1),

--- a/db/substate_encoding.go
+++ b/db/substate_encoding.go
@@ -100,11 +100,11 @@ func decodeRlp(bytes []byte, lookup codeLookupFunc, block uint64, tx int) (*subs
 
 // encodeRlp encodes substate into rlp-encoded bytes
 func encodeRlp(ss *substate.Substate, block uint64, tx int) ([]byte, error) {
-	bytes, err := trlp.EncodeToBytes(rlp.NewRLP(ss))
+	t := rlp.NewRLP(ss)
+	bytes, err := trlp.EncodeToBytes(t)
 	if err != nil {
 		return nil, fmt.Errorf("cannot encode substate into rlp block: %v, tx %v; %w", block, tx, err)
 	}
-
 	return bytes, nil
 }
 

--- a/db/substate_encoding_test.go
+++ b/db/substate_encoding_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/holiman/uint256"
+
 	"github.com/0xsoniclabs/substate/protobuf"
 	"github.com/0xsoniclabs/substate/substate"
 	"github.com/0xsoniclabs/substate/types"
@@ -161,7 +163,7 @@ func getSubstate() *substate.Substate {
 		InputSubstate: substate.WorldState{
 			types.Address{0x01}: &substate.Account{
 				Nonce:   1,
-				Balance: big.NewInt(1000),
+				Balance: uint256.NewInt(1000),
 				Storage: map[types.Hash]types.Hash{
 					{0x01}: {0x02},
 				},
@@ -170,7 +172,7 @@ func getSubstate() *substate.Substate {
 		OutputSubstate: substate.WorldState{
 			types.Address{0x04}: &substate.Account{
 				Nonce:   1,
-				Balance: big.NewInt(2000),
+				Balance: uint256.NewInt(2000),
 				Storage: map[types.Hash]types.Hash{
 					{0xCD}: {0xAB},
 				},

--- a/db/substate_task_test.go
+++ b/db/substate_task_test.go
@@ -2,8 +2,9 @@ package db
 
 import (
 	"errors"
-	"math/big"
 	"testing"
+
+	"github.com/holiman/uint256"
 
 	"github.com/0xsoniclabs/substate/substate"
 	"github.com/stretchr/testify/assert"
@@ -260,7 +261,7 @@ func TestSubstateTaskPool_ExecuteBlockSkipSuccess(t *testing.T) {
 	value1 := getTestSubstate("default")
 	value2 := getTestSubstate("default")
 	value2.InputSubstate[*input.Message.To] = substate.NewAccount(
-		0, big.NewInt(0), []byte("code"),
+		0, uint256.NewInt(0), []byte("code"),
 	)
 	value3 := getTestSubstate("default")
 	value3.Message.To = nil

--- a/db/update_db_test.go
+++ b/db/update_db_test.go
@@ -3,8 +3,9 @@ package db
 import (
 	"errors"
 	"fmt"
-	"math/big"
 	"testing"
+
+	"github.com/holiman/uint256"
 
 	trlp "github.com/0xsoniclabs/substate/types/rlp"
 	"github.com/stretchr/testify/assert"
@@ -22,11 +23,11 @@ var testUpdateSet = &updateset.UpdateSet{
 	WorldState: substate.WorldState{
 		types.Address{1}: &substate.Account{
 			Nonce:   1,
-			Balance: new(big.Int).SetUint64(1),
+			Balance: new(uint256.Int).SetUint64(1),
 		},
 		types.Address{2}: &substate.Account{
 			Nonce:   2,
-			Balance: new(big.Int).SetUint64(2),
+			Balance: new(uint256.Int).SetUint64(2),
 		},
 	},
 	Block: 1,
@@ -315,7 +316,7 @@ func TestUpdateDB_GetUpdateSetSuccess(t *testing.T) {
 
 	encodedData, _ := trlp.EncodeToBytes(updateset.UpdateSetRLP{
 		WorldState: updateset.UpdateSet{
-			WorldState:      substate.NewWorldState().Add(types.Address{1}, 1, new(big.Int).SetUint64(1), nil),
+			WorldState:      substate.NewWorldState().Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), nil),
 			Block:           0,
 			DeletedAccounts: []types.Address{},
 		}.ToWorldStateRLP(),
@@ -380,7 +381,7 @@ func TestUpdateDB_PutUpdateSetSuccess(t *testing.T) {
 		WorldState: substate.WorldState{
 			types.Address{1}: &substate.Account{
 				Nonce:   1,
-				Balance: new(big.Int).SetUint64(1),
+				Balance: new(uint256.Int).SetUint64(1),
 				Code:    []byte{0x01, 0x02},
 			},
 		},
@@ -410,7 +411,7 @@ func TestUpdateDB_PutUpdateSetFail(t *testing.T) {
 		WorldState: substate.WorldState{
 			types.Address{1}: &substate.Account{
 				Nonce:   1,
-				Balance: new(big.Int).SetUint64(1),
+				Balance: new(uint256.Int).SetUint64(1),
 				Code:    []byte{0x01, 0x02},
 			},
 		},
@@ -483,7 +484,7 @@ func TestUpdateDB_NewUpdateSetIterator(t *testing.T) {
 	kv := &testutil.KeyValue{}
 	rlpData, _ := trlp.EncodeToBytes(updateset.UpdateSetRLP{
 		WorldState: updateset.UpdateSet{
-			WorldState:      substate.NewWorldState().Add(types.Address{1}, 1, new(big.Int).SetUint64(1), nil),
+			WorldState:      substate.NewWorldState().Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), nil),
 			Block:           0,
 			DeletedAccounts: []types.Address{},
 		}.ToWorldStateRLP(),

--- a/db/update_set_iterator_test.go
+++ b/db/update_set_iterator_test.go
@@ -2,9 +2,10 @@ package db
 
 import (
 	"errors"
-	"math/big"
 	"testing"
 	"time"
+
+	"github.com/holiman/uint256"
 
 	"github.com/0xsoniclabs/substate/substate"
 	"github.com/0xsoniclabs/substate/types"
@@ -101,7 +102,7 @@ func TestUpdateSetIterator_DecodeSuccess(t *testing.T) {
 
 	// Create sample RLP data
 	mockWorldState := updateset.UpdateSet{
-		WorldState:      substate.NewWorldState().Add(types.Address{1}, 1, new(big.Int).SetUint64(1), nil),
+		WorldState:      substate.NewWorldState().Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), nil),
 		Block:           0,
 		DeletedAccounts: []types.Address{},
 	}
@@ -165,7 +166,7 @@ func TestUpdateSetIterator_DecodeFail(t *testing.T) {
 	// Create sample update set
 	// Create sample RLP data
 	mockWorldState := updateset.UpdateSet{
-		WorldState:      substate.NewWorldState().Add(types.Address{1}, 1, new(big.Int).SetUint64(1), nil),
+		WorldState:      substate.NewWorldState().Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), nil),
 		Block:           0,
 		DeletedAccounts: []types.Address{},
 	}
@@ -199,7 +200,7 @@ func TestUpdateSetIterator_StartSuccess(t *testing.T) {
 
 	rlpData, _ := rlp.EncodeToBytes(updateset.UpdateSetRLP{
 		WorldState: updateset.UpdateSet{
-			WorldState:      substate.NewWorldState().Add(types.Address{1}, 1, new(big.Int).SetUint64(1), nil),
+			WorldState:      substate.NewWorldState().Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), nil),
 			Block:           0,
 			DeletedAccounts: []types.Address{},
 		}.ToWorldStateRLP(),
@@ -233,7 +234,7 @@ func TestUpdateSetIterator_StartDecodeKeyFail(t *testing.T) {
 
 	rlpData, _ := rlp.EncodeToBytes(updateset.UpdateSetRLP{
 		WorldState: updateset.UpdateSet{
-			WorldState:      substate.NewWorldState().Add(types.Address{1}, 1, new(big.Int).SetUint64(1), nil),
+			WorldState:      substate.NewWorldState().Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), nil),
 			Block:           0,
 			DeletedAccounts: []types.Address{},
 		}.ToWorldStateRLP(),
@@ -264,7 +265,7 @@ func TestUpdateSetIterator_StartDecodeValueFail(t *testing.T) {
 
 	rlpData, _ := rlp.EncodeToBytes(updateset.UpdateSetRLP{
 		WorldState: updateset.UpdateSet{
-			WorldState:      substate.NewWorldState().Add(types.Address{1}, 1, new(big.Int).SetUint64(1), nil),
+			WorldState:      substate.NewWorldState().Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), nil),
 			Block:           0,
 			DeletedAccounts: []types.Address{},
 		}.ToWorldStateRLP(),

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.22.11
 
 require (
 	github.com/golang/protobuf v1.5.4
+	github.com/holiman/uint256 v1.3.2
 	github.com/stretchr/testify v1.9.0
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/urfave/cli/v2 v2.25.7

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/holiman/uint256 v1.3.2 h1:a9EgMPSC1AAaj1SZL5zIQD3WbwTuHrMGOerLjGmM/TA=
+github.com/holiman/uint256 v1.3.2/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/protobuf/decode.go
+++ b/protobuf/decode.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/holiman/uint256"
+
 	"github.com/0xsoniclabs/substate/substate"
 	"github.com/0xsoniclabs/substate/types"
 	"github.com/0xsoniclabs/substate/types/hash"
@@ -75,9 +77,9 @@ func (entry *Substate_AllocEntry) decode() ([]byte, *Substate_Account) {
 	return entry.GetAddress(), entry.GetAccount()
 }
 
-func (acct *Substate_Account) decode() (uint64, *big.Int, []byte, types.Hash) {
+func (acct *Substate_Account) decode() (uint64, *uint256.Int, []byte, types.Hash) {
 	return acct.GetNonce(),
-		BytesToBigInt(acct.GetBalance()),
+		BytesToUint256(acct.GetBalance()),
 		acct.GetCode(),
 		types.BytesToHash(acct.GetCodeHash())
 }

--- a/protobuf/encode_test.go
+++ b/protobuf/encode_test.go
@@ -6,6 +6,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/holiman/uint256"
+
 	"google.golang.org/protobuf/proto"
 
 	"github.com/0xsoniclabs/substate/substate"
@@ -32,7 +34,7 @@ func TestEncode_EncodeSuccess(t *testing.T) {
 		InputSubstate: substate.WorldState{
 			types.Address{0x01}: &substate.Account{
 				Nonce:   1,
-				Balance: big.NewInt(1000),
+				Balance: uint256.NewInt(1000),
 				Storage: map[types.Hash]types.Hash{
 					{0x01}: {0x02},
 				},
@@ -42,7 +44,7 @@ func TestEncode_EncodeSuccess(t *testing.T) {
 		OutputSubstate: substate.WorldState{
 			types.Address{0x04}: &substate.Account{
 				Nonce:   1,
-				Balance: big.NewInt(2000),
+				Balance: uint256.NewInt(2000),
 				Storage: map[types.Hash]types.Hash{
 					{0xCD}: {0xAB},
 				},
@@ -122,7 +124,7 @@ func TestEncode_WorldState(t *testing.T) {
 	ws := substate.WorldState{
 		types.Address{1}: {
 			Nonce:   1,
-			Balance: big.NewInt(100),
+			Balance: uint256.NewInt(100),
 			Storage: map[types.Hash]types.Hash{
 				{1}: {2},
 			},

--- a/protobuf/utils.go
+++ b/protobuf/utils.go
@@ -7,6 +7,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/0xsoniclabs/substate/types"
+	"github.com/holiman/uint256"
 	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -59,6 +60,13 @@ func BytesToBigInt(b []byte) *big.Int {
 		return nil
 	}
 	return new(big.Int).SetBytes(b)
+}
+
+func BytesToUint256(b []byte) *uint256.Int {
+	if b == nil {
+		return nil
+	}
+	return new(uint256.Int).SetBytes(b)
 }
 
 func BigIntToBytes(i *big.Int) []byte {

--- a/protobuf/utils_test.go
+++ b/protobuf/utils_test.go
@@ -5,6 +5,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/holiman/uint256"
+
 	"github.com/0xsoniclabs/substate/types/hash"
 
 	"github.com/0xsoniclabs/substate/types"
@@ -210,6 +212,14 @@ func TestBytesToBigInt(t *testing.T) {
 
 	bigInt = BytesToBigInt(nil)
 	assert.Nil(t, bigInt)
+}
+
+func TestBytesToUint256(t *testing.T) {
+	b := []byte{0x01, 0x02, 0x03, 0x04}
+
+	actual := BytesToUint256(b)
+	expected := new(uint256.Int).SetBytes(b)
+	assert.Equal(t, expected, actual)
 }
 
 func TestCodeHash(t *testing.T) {

--- a/rlp/rlp_account.go
+++ b/rlp/rlp_account.go
@@ -1,8 +1,9 @@
 package rlp
 
 import (
-	"math/big"
 	"sort"
+
+	"github.com/holiman/uint256"
 
 	"github.com/0xsoniclabs/substate/substate"
 	"github.com/0xsoniclabs/substate/types"
@@ -11,7 +12,7 @@ import (
 func NewRLPAccount(acc *substate.Account) *SubstateAccountRLP {
 	a := &SubstateAccountRLP{
 		Nonce:    acc.Nonce,
-		Balance:  new(big.Int).Set(acc.Balance),
+		Balance:  new(uint256.Int).Set(acc.Balance),
 		CodeHash: acc.CodeHash(),
 		Storage:  [][2]types.Hash{},
 	}
@@ -35,7 +36,7 @@ func NewRLPAccount(acc *substate.Account) *SubstateAccountRLP {
 
 type SubstateAccountRLP struct {
 	Nonce    uint64
-	Balance  *big.Int
+	Balance  *uint256.Int
 	CodeHash types.Hash
 	Storage  [][2]types.Hash
 }

--- a/rlp/rlp_test.go
+++ b/rlp/rlp_test.go
@@ -5,6 +5,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/holiman/uint256"
+
 	"github.com/0xsoniclabs/substate/types"
 	"github.com/0xsoniclabs/substate/types/rlp"
 )
@@ -101,7 +103,7 @@ func Test_ToSubstateLooksAccountsCodeHashInDatabase(t *testing.T) {
 		OutputSubstate: WorldState{
 			Addresses: []types.Address{addr1},
 			Accounts: []*SubstateAccountRLP{{
-				Balance:  big.NewInt(10),
+				Balance:  uint256.NewInt(10),
 				CodeHash: baseHash,
 			}},
 		},

--- a/substate/account.go
+++ b/substate/account.go
@@ -3,8 +3,9 @@ package substate
 import (
 	"bytes"
 	"fmt"
-	"math/big"
 	"strings"
+
+	"github.com/holiman/uint256"
 
 	"github.com/0xsoniclabs/substate/types"
 	"github.com/0xsoniclabs/substate/types/hash"
@@ -13,12 +14,12 @@ import (
 // Account holds any information about account used in a transaction.
 type Account struct {
 	Nonce   uint64
-	Balance *big.Int
+	Balance *uint256.Int
 	Storage map[types.Hash]types.Hash
 	Code    []byte
 }
 
-func NewAccount(nonce uint64, balance *big.Int, code []byte) *Account {
+func NewAccount(nonce uint64, balance *uint256.Int, code []byte) *Account {
 	return &Account{
 		Nonce:   nonce,
 		Balance: balance,

--- a/substate/account_test.go
+++ b/substate/account_test.go
@@ -4,6 +4,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/holiman/uint256"
+
 	"github.com/0xsoniclabs/substate/types/hash"
 	"github.com/stretchr/testify/assert"
 
@@ -11,8 +13,8 @@ import (
 )
 
 func TestAccount_EqualNonce(t *testing.T) {
-	acc := NewAccount(1, new(big.Int).SetUint64(1), []byte{1})
-	comparedNonceAcc := NewAccount(2, new(big.Int).SetUint64(1), []byte{1})
+	acc := NewAccount(1, new(uint256.Int).SetUint64(1), []byte{1})
+	comparedNonceAcc := NewAccount(2, new(uint256.Int).SetUint64(1), []byte{1})
 
 	if acc.Equal(comparedNonceAcc) {
 		t.Fatal("accounts nonce are different but equal returned true")
@@ -25,8 +27,8 @@ func TestAccount_EqualNonce(t *testing.T) {
 }
 
 func TestAccount_EqualBalance(t *testing.T) {
-	acc := NewAccount(1, new(big.Int).SetUint64(1), []byte{1})
-	comparedBalanceAcc := NewAccount(1, new(big.Int).SetUint64(2), []byte{1})
+	acc := NewAccount(1, new(uint256.Int).SetUint64(1), []byte{1})
+	comparedBalanceAcc := NewAccount(1, new(uint256.Int).SetUint64(2), []byte{1})
 
 	if acc.Equal(comparedBalanceAcc) {
 		t.Fatal("accounts balances are different but equal returned true")
@@ -43,12 +45,12 @@ func TestAccount_EqualStorage(t *testing.T) {
 	hashTwo := types.BigToHash(new(big.Int).SetUint64(2))
 	hashThree := types.BigToHash(new(big.Int).SetUint64(3))
 
-	acc := NewAccount(1, new(big.Int).SetUint64(1), []byte{1})
+	acc := NewAccount(1, new(uint256.Int).SetUint64(1), []byte{1})
 	acc.Storage = make(map[types.Hash]types.Hash)
 	acc.Storage[hashOne] = hashTwo
 
 	// first compare with no storage
-	comparedStorageAcc := NewAccount(1, new(big.Int).SetUint64(1), []byte{1})
+	comparedStorageAcc := NewAccount(1, new(uint256.Int).SetUint64(1), []byte{1})
 	if acc.Equal(comparedStorageAcc) {
 		t.Fatal("accounts storages are different but equal returned true")
 	}
@@ -77,8 +79,8 @@ func TestAccount_EqualStorage(t *testing.T) {
 }
 
 func TestAccount_EqualCode(t *testing.T) {
-	acc := NewAccount(1, new(big.Int).SetUint64(1), []byte{1})
-	comparedCodeAcc := NewAccount(1, new(big.Int).SetUint64(1), []byte{2})
+	acc := NewAccount(1, new(uint256.Int).SetUint64(1), []byte{1})
+	comparedCodeAcc := NewAccount(1, new(uint256.Int).SetUint64(1), []byte{2})
 	if acc.Equal(comparedCodeAcc) {
 		t.Fatal("accounts codes are different but equal returned true")
 	}
@@ -93,7 +95,7 @@ func TestAccount_EqualCode(t *testing.T) {
 func TestAccount_Copy(t *testing.T) {
 	hashOne := types.BigToHash(new(big.Int).SetUint64(1))
 	hashTwo := types.BigToHash(new(big.Int).SetUint64(2))
-	acc := NewAccount(1, new(big.Int).SetUint64(1), []byte{1})
+	acc := NewAccount(1, new(uint256.Int).SetUint64(1), []byte{1})
 	acc.Storage = make(map[types.Hash]types.Hash)
 	acc.Storage[hashOne] = hashTwo
 
@@ -104,7 +106,7 @@ func TestAccount_Copy(t *testing.T) {
 }
 
 func TestAccount_CodeHash(t *testing.T) {
-	acc := NewAccount(1, new(big.Int).SetUint64(1), []byte{1})
+	acc := NewAccount(1, new(uint256.Int).SetUint64(1), []byte{1})
 	expectedHash := hash.Keccak256Hash(acc.Code)
 	assert.Equal(t, expectedHash, acc.CodeHash())
 }
@@ -112,7 +114,7 @@ func TestAccount_CodeHash(t *testing.T) {
 func TestAccount_String(t *testing.T) {
 	hashOne := types.BigToHash(new(big.Int).SetUint64(1))
 	hashTwo := types.BigToHash(new(big.Int).SetUint64(2))
-	acc := NewAccount(1, new(big.Int).SetUint64(1), []byte{1})
+	acc := NewAccount(1, new(uint256.Int).SetUint64(1), []byte{1})
 	acc.Storage = make(map[types.Hash]types.Hash)
 	acc.Storage[hashOne] = hashTwo
 	expectedString := "Nonce: 1\nBalance: 1\nCode: \x01\nStorage:0x0000000000000000000000000000000000000000000000000000000000000001: 0x0000000000000000000000000000000000000000000000000000000000000002\n"
@@ -120,11 +122,11 @@ func TestAccount_String(t *testing.T) {
 }
 
 func TestAccount_EqualSelf(t *testing.T) {
-	acc := NewAccount(1, new(big.Int).SetUint64(1), []byte{1})
+	acc := NewAccount(1, new(uint256.Int).SetUint64(1), []byte{1})
 	assert.Equal(t, true, acc.Equal(acc))
 }
 
 func TestAccount_EqualNil(t *testing.T) {
-	acc := NewAccount(1, new(big.Int).SetUint64(1), []byte{1})
+	acc := NewAccount(1, new(uint256.Int).SetUint64(1), []byte{1})
 	assert.Equal(t, false, acc.Equal(nil))
 }

--- a/substate/substate_test.go
+++ b/substate/substate_test.go
@@ -1,8 +1,9 @@
 package substate
 
 import (
-	"math/big"
 	"testing"
+
+	"github.com/holiman/uint256"
 
 	"github.com/0xsoniclabs/substate/types"
 	"github.com/stretchr/testify/assert"
@@ -47,7 +48,7 @@ func TestSubstate_Equal(t *testing.T) {
 
 	// preState test
 	candidate := NewSubstate(
-		NewWorldState().Add(types.Address{1}, 1, new(big.Int).SetUint64(1), nil),
+		NewWorldState().Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), nil),
 		postState, env, message, result, block, transaction,
 	)
 	assert.NotNil(t, substate.Equal(candidate))
@@ -55,7 +56,7 @@ func TestSubstate_Equal(t *testing.T) {
 	// postState test
 	candidate = NewSubstate(
 		preState,
-		NewWorldState().Add(types.Address{1}, 1, new(big.Int).SetUint64(1), nil),
+		NewWorldState().Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), nil),
 		env, message, result, block, transaction,
 	)
 	assert.NotNil(t, substate.Equal(candidate))

--- a/substate/world_state.go
+++ b/substate/world_state.go
@@ -3,8 +3,9 @@ package substate
 import (
 	"bytes"
 	"fmt"
-	"math/big"
 	"strings"
+
+	"github.com/holiman/uint256"
 
 	"github.com/0xsoniclabs/substate/types"
 )
@@ -22,7 +23,7 @@ func NewWorldState() WorldState {
 type WorldState map[types.Address]*Account
 
 // Add assigns new Account to an Address
-func (ws WorldState) Add(addr types.Address, nonce uint64, balance *big.Int, code []byte) WorldState {
+func (ws WorldState) Add(addr types.Address, nonce uint64, balance *uint256.Int, code []byte) WorldState {
 	ws[addr] = NewAccount(nonce, balance, code)
 	return ws
 }
@@ -37,7 +38,7 @@ func (ws WorldState) Merge(y WorldState) {
 
 			// overwrite yAcc details in ws by y
 			ws[yAddr].Nonce = yAcc.Nonce
-			ws[yAddr].Balance = new(big.Int).Set(yAcc.Balance)
+			ws[yAddr].Balance = new(uint256.Int).Set(yAcc.Balance)
 			ws[yAddr].Code = make([]byte, len(yAcc.Code))
 			copy(ws[yAddr].Code, yAcc.Code)
 		} else {

--- a/substate/world_state_test.go
+++ b/substate/world_state_test.go
@@ -4,6 +4,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/holiman/uint256"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/0xsoniclabs/substate/types"
@@ -14,11 +16,11 @@ func TestWorldState_Add(t *testing.T) {
 	addr2 := types.Address{2}
 	acc := &Account{
 		Nonce:   2,
-		Balance: new(big.Int).SetUint64(2),
+		Balance: new(uint256.Int).SetUint64(2),
 		Code:    []byte{2},
 	}
 
-	worldState := make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1})
+	worldState := make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1})
 	worldState.Add(addr2, acc.Nonce, acc.Balance, acc.Code)
 
 	if len(worldState) != 2 {
@@ -33,14 +35,14 @@ func TestWorldState_Add(t *testing.T) {
 func TestWorldState_MergeOneAccount(t *testing.T) {
 	addr := types.Address{1}
 
-	worldState := make(WorldState).Add(addr, 1, new(big.Int).SetUint64(1), []byte{1})
-	worldStateToMerge := make(WorldState).Add(addr, 2, new(big.Int).SetUint64(2), []byte{2})
+	worldState := make(WorldState).Add(addr, 1, new(uint256.Int).SetUint64(1), []byte{1})
+	worldStateToMerge := make(WorldState).Add(addr, 2, new(uint256.Int).SetUint64(2), []byte{2})
 
 	worldState.Merge(worldStateToMerge)
 
 	acc := &Account{
 		Nonce:   2,
-		Balance: new(big.Int).SetUint64(2),
+		Balance: new(uint256.Int).SetUint64(2),
 		Code:    []byte{2},
 	}
 
@@ -54,14 +56,14 @@ func TestWorldState_MergeTwoAccounts(t *testing.T) {
 	addr1 := types.Address{1}
 	addr2 := types.Address{2}
 
-	worldState := make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1})
-	worldStateToMerge := make(WorldState).Add(addr2, 2, new(big.Int).SetUint64(2), []byte{2})
+	worldState := make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1})
+	worldStateToMerge := make(WorldState).Add(addr2, 2, new(uint256.Int).SetUint64(2), []byte{2})
 
 	worldState.Merge(worldStateToMerge)
 
 	want1 := &Account{
 		Nonce:   1,
-		Balance: new(big.Int).SetUint64(1),
+		Balance: new(uint256.Int).SetUint64(1),
 		Code:    []byte{1},
 	}
 
@@ -75,7 +77,7 @@ func TestWorldState_MergeTwoAccounts(t *testing.T) {
 
 	want2 := &Account{
 		Nonce:   2,
-		Balance: new(big.Int).SetUint64(2),
+		Balance: new(uint256.Int).SetUint64(2),
 		Code:    []byte{2},
 	}
 
@@ -89,8 +91,8 @@ func TestWorldState_EstimateIncrementalSize_NewWorldState(t *testing.T) {
 	addr1 := types.Address{1}
 	addr2 := types.Address{2}
 
-	worldState := make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1})
-	worldStateToEstimate := make(WorldState).Add(addr2, 2, new(big.Int).SetUint64(2), []byte{2})
+	worldState := make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1})
+	worldStateToEstimate := make(WorldState).Add(addr2, 2, new(uint256.Int).SetUint64(2), []byte{2})
 
 	want := sizeOfAddress + sizeOfNonce + uint64(len(worldStateToEstimate[addr2].Balance.Bytes())) + sizeOfHash
 
@@ -103,8 +105,8 @@ func TestWorldState_EstimateIncrementalSize_NewWorldState(t *testing.T) {
 func TestWorldState_EstimateIncrementalSize_SameWorldState(t *testing.T) {
 	addr1 := types.Address{1}
 
-	worldState := make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1})
-	worldStateToEstimate := make(WorldState).Add(addr1, 2, new(big.Int).SetUint64(2), []byte{2})
+	worldState := make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1})
+	worldStateToEstimate := make(WorldState).Add(addr1, 2, new(uint256.Int).SetUint64(2), []byte{2})
 
 	// since we don't add anything, size should not be increased
 	if got := worldState.EstimateIncrementalSize(worldStateToEstimate); got != 0 {
@@ -115,8 +117,8 @@ func TestWorldState_EstimateIncrementalSize_SameWorldState(t *testing.T) {
 func TestWorldState_EstimateIncrementalSize_AddingStorageHash(t *testing.T) {
 	addr1 := types.Address{1}
 
-	worldState := make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1})
-	worldStateToEstimate := make(WorldState).Add(addr1, 2, new(big.Int).SetUint64(2), []byte{2})
+	worldState := make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1})
+	worldStateToEstimate := make(WorldState).Add(addr1, 2, new(uint256.Int).SetUint64(2), []byte{2})
 	worldStateToEstimate[addr1].Storage[types.Hash{1}] = types.Hash{1}
 
 	// we add one key to already existing account, this size is increased by the sizeOfHash
@@ -128,8 +130,8 @@ func TestWorldState_EstimateIncrementalSize_AddingStorageHash(t *testing.T) {
 // todo diff tests
 
 func TestWorldState_Equal(t *testing.T) {
-	worldState := make(WorldState).Add(types.Address{1}, 1, new(big.Int).SetUint64(1), []byte{1})
-	comparedWorldStateEqual := make(WorldState).Add(types.Address{1}, 1, new(big.Int).SetUint64(1), []byte{1})
+	worldState := make(WorldState).Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), []byte{1})
+	comparedWorldStateEqual := make(WorldState).Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), []byte{1})
 
 	if !worldState.Equal(comparedWorldStateEqual) {
 		t.Fatal("world states are same but equal returned false")
@@ -137,8 +139,8 @@ func TestWorldState_Equal(t *testing.T) {
 }
 
 func TestWorldState_NotEqual(t *testing.T) {
-	worldState := make(WorldState).Add(types.Address{1}, 1, new(big.Int).SetUint64(1), []byte{1})
-	comparedWorldStateEqual := make(WorldState).Add(types.Address{2}, 1, new(big.Int).SetUint64(1), []byte{1})
+	worldState := make(WorldState).Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), []byte{1})
+	comparedWorldStateEqual := make(WorldState).Add(types.Address{2}, 1, new(uint256.Int).SetUint64(1), []byte{1})
 
 	if worldState.Equal(comparedWorldStateEqual) {
 		t.Fatal("world states are different but equal returned false")
@@ -146,11 +148,11 @@ func TestWorldState_NotEqual(t *testing.T) {
 }
 
 func TestWorldState_NotEqual_DifferentLen(t *testing.T) {
-	worldState := make(WorldState).Add(types.Address{1}, 1, new(big.Int).SetUint64(1), []byte{1})
-	comparedWorldStateEqual := make(WorldState).Add(types.Address{2}, 1, new(big.Int).SetUint64(1), []byte{1})
+	worldState := make(WorldState).Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), []byte{1})
+	comparedWorldStateEqual := make(WorldState).Add(types.Address{2}, 1, new(uint256.Int).SetUint64(1), []byte{1})
 
 	// add one more acc to world state
-	worldState.Add(types.Address{2}, 1, new(big.Int).SetUint64(1), []byte{1})
+	worldState.Add(types.Address{2}, 1, new(uint256.Int).SetUint64(1), []byte{1})
 
 	if worldState.Equal(comparedWorldStateEqual) {
 		t.Fatal("world states are different but equal returned false")
@@ -160,7 +162,7 @@ func TestWorldState_NotEqual_DifferentLen(t *testing.T) {
 func TestWorld_Copy(t *testing.T) {
 	hashOne := types.BigToHash(new(big.Int).SetUint64(1))
 	hashTwo := types.BigToHash(new(big.Int).SetUint64(2))
-	acc := NewAccount(1, new(big.Int).SetUint64(1), []byte{1})
+	acc := NewAccount(1, new(uint256.Int).SetUint64(1), []byte{1})
 	acc.Storage = make(map[types.Hash]types.Hash)
 	acc.Storage[hashOne] = hashTwo
 
@@ -188,36 +190,36 @@ func TestWorldState_Diff(t *testing.T) {
 		},
 		{
 			name:     "account only in first state",
-			ws1:      make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1}),
+			ws1:      make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1}),
 			ws2:      make(WorldState),
-			expected: make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1}),
+			expected: make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1}),
 		},
 		{
 			name:     "same account different values",
-			ws1:      make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1}),
-			ws2:      make(WorldState).Add(addr1, 2, new(big.Int).SetUint64(2), []byte{2}),
-			expected: make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1}),
+			ws1:      make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1}),
+			ws2:      make(WorldState).Add(addr1, 2, new(uint256.Int).SetUint64(2), []byte{2}),
+			expected: make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1}),
 		},
 		{
 			name:     "same account same values",
-			ws1:      make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1}),
-			ws2:      make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1}),
+			ws1:      make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1}),
+			ws2:      make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1}),
 			expected: make(WorldState),
 		},
 		{
 			name: "different storage values",
 			ws1: func() WorldState {
-				ws := make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1})
+				ws := make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1})
 				ws[addr1].Storage[types.Hash{1}] = types.Hash{2}
 				return ws
 			}(),
 			ws2: func() WorldState {
-				ws := make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1})
+				ws := make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1})
 				ws[addr1].Storage[types.Hash{1}] = types.Hash{3}
 				return ws
 			}(),
 			expected: func() WorldState {
-				ws := make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1})
+				ws := make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1})
 				ws[addr1].Storage[types.Hash{1}] = types.Hash{2}
 				return ws
 			}(),
@@ -225,13 +227,13 @@ func TestWorldState_Diff(t *testing.T) {
 		{
 			name: "storage value exists only in first state",
 			ws1: func() WorldState {
-				ws := make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1})
+				ws := make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1})
 				ws[addr1].Storage[types.Hash{1}] = types.Hash{2}
 				return ws
 			}(),
-			ws2: make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1}),
+			ws2: make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1}),
 			expected: func() WorldState {
-				ws := make(WorldState).Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1})
+				ws := make(WorldState).Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1})
 				ws[addr1].Storage[types.Hash{1}] = types.Hash{2}
 				return ws
 			}(),
@@ -240,23 +242,23 @@ func TestWorldState_Diff(t *testing.T) {
 			name: "multiple accounts with different storages",
 			ws1: func() WorldState {
 				ws := make(WorldState)
-				ws.Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1})
-				ws.Add(addr2, 2, new(big.Int).SetUint64(2), []byte{2})
+				ws.Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1})
+				ws.Add(addr2, 2, new(uint256.Int).SetUint64(2), []byte{2})
 				ws[addr1].Storage[types.Hash{1}] = types.Hash{2}
 				ws[addr2].Storage[types.Hash{3}] = types.Hash{4}
 				return ws
 			}(),
 			ws2: func() WorldState {
 				ws := make(WorldState)
-				ws.Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1})
-				ws.Add(addr2, 2, new(big.Int).SetUint64(2), []byte{2})
+				ws.Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1})
+				ws.Add(addr2, 2, new(uint256.Int).SetUint64(2), []byte{2})
 				ws[addr1].Storage[types.Hash{1}] = types.Hash{3}
 				return ws
 			}(),
 			expected: func() WorldState {
 				ws := make(WorldState)
-				ws.Add(addr1, 1, new(big.Int).SetUint64(1), []byte{1})
-				ws.Add(addr2, 2, new(big.Int).SetUint64(2), []byte{2})
+				ws.Add(addr1, 1, new(uint256.Int).SetUint64(1), []byte{1})
+				ws.Add(addr2, 2, new(uint256.Int).SetUint64(2), []byte{2})
 				ws[addr1].Storage[types.Hash{1}] = types.Hash{2}
 				ws[addr2].Storage[types.Hash{3}] = types.Hash{4}
 				return ws
@@ -290,7 +292,7 @@ func TestWorldState_EstimateIncrementalSize(t *testing.T) {
 			ws:   make(WorldState),
 			y: func() WorldState {
 				ws := make(WorldState)
-				ws.Add(types.Address{1}, 1, new(big.Int).SetUint64(1), []byte{1})
+				ws.Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), []byte{1})
 				return ws
 			}(),
 			// address + nonce + balance (1 byte) + codehash
@@ -301,7 +303,7 @@ func TestWorldState_EstimateIncrementalSize(t *testing.T) {
 			ws:   make(WorldState),
 			y: func() WorldState {
 				ws := make(WorldState)
-				acc := ws.Add(types.Address{1}, 1, new(big.Int).SetUint64(1), []byte{1})
+				acc := ws.Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), []byte{1})
 				acc[types.Address{1}].Storage[types.Hash{1}] = types.Hash{2}
 				acc[types.Address{1}].Storage[types.Hash{2}] = types.Hash{3}
 				return ws
@@ -312,10 +314,10 @@ func TestWorldState_EstimateIncrementalSize(t *testing.T) {
 		{
 			name: "existing account with same values",
 			ws: func() WorldState {
-				return make(WorldState).Add(types.Address{1}, 1, new(big.Int).SetUint64(1), []byte{1})
+				return make(WorldState).Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), []byte{1})
 			}(),
 			y: func() WorldState {
-				return make(WorldState).Add(types.Address{1}, 1, new(big.Int).SetUint64(1), []byte{1})
+				return make(WorldState).Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), []byte{1})
 			}(),
 			expected: 0,
 		},
@@ -323,13 +325,13 @@ func TestWorldState_EstimateIncrementalSize(t *testing.T) {
 			name: "existing account with new storage keys",
 			ws: func() WorldState {
 				ws := make(WorldState)
-				acc := ws.Add(types.Address{1}, 1, new(big.Int).SetUint64(1), []byte{1})
+				acc := ws.Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), []byte{1})
 				acc[types.Address{1}].Storage[types.Hash{1}] = types.Hash{2}
 				return ws
 			}(),
 			y: func() WorldState {
 				ws := make(WorldState)
-				acc := ws.Add(types.Address{1}, 1, new(big.Int).SetUint64(1), []byte{1})
+				acc := ws.Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), []byte{1})
 				acc[types.Address{1}].Storage[types.Hash{1}] = types.Hash{2}
 				acc[types.Address{1}].Storage[types.Hash{2}] = types.Hash{3}
 				return ws
@@ -341,18 +343,18 @@ func TestWorldState_EstimateIncrementalSize(t *testing.T) {
 			name: "multiple accounts with mixed scenarios",
 			ws: func() WorldState {
 				ws := make(WorldState)
-				acc1 := ws.Add(types.Address{1}, 1, new(big.Int).SetUint64(1), []byte{1})
+				acc1 := ws.Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), []byte{1})
 				acc1[types.Address{1}].Storage[types.Hash{1}] = types.Hash{2}
 				return ws
 			}(),
 			y: func() WorldState {
 				ws := make(WorldState)
 				// existing account with new storage
-				acc1 := ws.Add(types.Address{1}, 1, new(big.Int).SetUint64(1), []byte{1})
+				acc1 := ws.Add(types.Address{1}, 1, new(uint256.Int).SetUint64(1), []byte{1})
 				acc1[types.Address{1}].Storage[types.Hash{1}] = types.Hash{2}
 				acc1[types.Address{1}].Storage[types.Hash{2}] = types.Hash{3}
 				// completely new account with storage
-				acc2 := ws.Add(types.Address{2}, 2, new(big.Int).SetUint64(2), []byte{2})
+				acc2 := ws.Add(types.Address{2}, 2, new(uint256.Int).SetUint64(2), []byte{2})
 				acc2[types.Address{2}].Storage[types.Hash{3}] = types.Hash{4}
 				return ws
 			}(),
@@ -387,13 +389,13 @@ func TestWorldState_Merge(t *testing.T) {
 			ws:   make(WorldState),
 			y: func() WorldState {
 				ws := make(WorldState)
-				acc := ws.Add(types.Address{1}, 1, new(big.Int).SetUint64(100), []byte{1})
+				acc := ws.Add(types.Address{1}, 1, new(uint256.Int).SetUint64(100), []byte{1})
 				acc[types.Address{1}].Storage[types.Hash{1}] = types.Hash{2}
 				return ws
 			}(),
 			expected: func() WorldState {
 				ws := make(WorldState)
-				acc := ws.Add(types.Address{1}, 1, new(big.Int).SetUint64(100), []byte{1})
+				acc := ws.Add(types.Address{1}, 1, new(uint256.Int).SetUint64(100), []byte{1})
 				acc[types.Address{1}].Storage[types.Hash{1}] = types.Hash{2}
 				return ws
 			}(),
@@ -401,42 +403,42 @@ func TestWorldState_Merge(t *testing.T) {
 		{
 			name: "merge existing account with same values",
 			ws: func() WorldState {
-				return make(WorldState).Add(types.Address{1}, 1, new(big.Int).SetUint64(100), []byte{1})
+				return make(WorldState).Add(types.Address{1}, 1, new(uint256.Int).SetUint64(100), []byte{1})
 			}(),
 			y: func() WorldState {
-				return make(WorldState).Add(types.Address{1}, 1, new(big.Int).SetUint64(100), []byte{1})
+				return make(WorldState).Add(types.Address{1}, 1, new(uint256.Int).SetUint64(100), []byte{1})
 			}(),
 			expected: func() WorldState {
-				return make(WorldState).Add(types.Address{1}, 1, new(big.Int).SetUint64(100), []byte{1})
+				return make(WorldState).Add(types.Address{1}, 1, new(uint256.Int).SetUint64(100), []byte{1})
 			}(),
 		},
 		{
 			name: "merge existing account with different values",
 			ws: func() WorldState {
-				return make(WorldState).Add(types.Address{1}, 1, new(big.Int).SetUint64(100), []byte{1})
+				return make(WorldState).Add(types.Address{1}, 1, new(uint256.Int).SetUint64(100), []byte{1})
 			}(),
 			y: func() WorldState {
-				return make(WorldState).Add(types.Address{1}, 2, new(big.Int).SetUint64(200), []byte{2})
+				return make(WorldState).Add(types.Address{1}, 2, new(uint256.Int).SetUint64(200), []byte{2})
 			}(),
 			expected: func() WorldState {
-				return make(WorldState).Add(types.Address{1}, 2, new(big.Int).SetUint64(200), []byte{2})
+				return make(WorldState).Add(types.Address{1}, 2, new(uint256.Int).SetUint64(200), []byte{2})
 			}(),
 		},
 		{
 			name: "merge account with storage",
 			ws: func() WorldState {
-				ws := make(WorldState).Add(types.Address{1}, 1, new(big.Int).SetUint64(100), []byte{1})
+				ws := make(WorldState).Add(types.Address{1}, 1, new(uint256.Int).SetUint64(100), []byte{1})
 				ws[types.Address{1}].Storage[types.Hash{1}] = types.Hash{1}
 				return ws
 			}(),
 			y: func() WorldState {
-				ws := make(WorldState).Add(types.Address{1}, 1, new(big.Int).SetUint64(100), []byte{1})
+				ws := make(WorldState).Add(types.Address{1}, 1, new(uint256.Int).SetUint64(100), []byte{1})
 				ws[types.Address{1}].Storage[types.Hash{1}] = types.Hash{2}
 				ws[types.Address{1}].Storage[types.Hash{2}] = types.Hash{3}
 				return ws
 			}(),
 			expected: func() WorldState {
-				ws := make(WorldState).Add(types.Address{1}, 1, new(big.Int).SetUint64(100), []byte{1})
+				ws := make(WorldState).Add(types.Address{1}, 1, new(uint256.Int).SetUint64(100), []byte{1})
 				ws[types.Address{1}].Storage[types.Hash{1}] = types.Hash{2}
 				ws[types.Address{1}].Storage[types.Hash{2}] = types.Hash{3}
 				return ws
@@ -446,23 +448,23 @@ func TestWorldState_Merge(t *testing.T) {
 			name: "merge multiple accounts with storage",
 			ws: func() WorldState {
 				ws := make(WorldState)
-				acc1 := ws.Add(types.Address{1}, 1, new(big.Int).SetUint64(100), []byte{1})
+				acc1 := ws.Add(types.Address{1}, 1, new(uint256.Int).SetUint64(100), []byte{1})
 				acc1[types.Address{1}].Storage[types.Hash{1}] = types.Hash{1}
 				return ws
 			}(),
 			y: func() WorldState {
 				ws := make(WorldState)
-				acc1 := ws.Add(types.Address{1}, 2, new(big.Int).SetUint64(200), []byte{2})
+				acc1 := ws.Add(types.Address{1}, 2, new(uint256.Int).SetUint64(200), []byte{2})
 				acc1[types.Address{1}].Storage[types.Hash{1}] = types.Hash{2}
-				acc2 := ws.Add(types.Address{2}, 3, new(big.Int).SetUint64(300), []byte{3})
+				acc2 := ws.Add(types.Address{2}, 3, new(uint256.Int).SetUint64(300), []byte{3})
 				acc2[types.Address{2}].Storage[types.Hash{3}] = types.Hash{4}
 				return ws
 			}(),
 			expected: func() WorldState {
 				ws := make(WorldState)
-				acc1 := ws.Add(types.Address{1}, 2, new(big.Int).SetUint64(200), []byte{2})
+				acc1 := ws.Add(types.Address{1}, 2, new(uint256.Int).SetUint64(200), []byte{2})
 				acc1[types.Address{1}].Storage[types.Hash{1}] = types.Hash{2}
-				acc2 := ws.Add(types.Address{2}, 3, new(big.Int).SetUint64(300), []byte{3})
+				acc2 := ws.Add(types.Address{2}, 3, new(uint256.Int).SetUint64(300), []byte{3})
 				acc2[types.Address{2}].Storage[types.Hash{3}] = types.Hash{4}
 				return ws
 			}(),

--- a/types/rlp/decode_test.go
+++ b/types/rlp/decode_test.go
@@ -26,6 +26,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/holiman/uint256"
 )
 
 func TestStreamKind(t *testing.T) {
@@ -303,6 +305,10 @@ type simplestruct struct {
 	A uint
 	B string
 }
+type simpleUint256 struct {
+	A *uint256.Int
+	B uint256.Int
+}
 
 type recstruct struct {
 	I     uint
@@ -474,6 +480,11 @@ var decodeTests = []decodeTest{
 	{input: "00", ptr: new(*big.Int), error: "rlp: non-canonical integer (leading zero bytes) for *big.Int"},
 	{input: "820001", ptr: new(*big.Int), error: "rlp: non-canonical integer (leading zero bytes) for *big.Int"},
 	{input: "8105", ptr: new(*big.Int), error: "rlp: non-canonical size information for *big.Int"},
+
+	// uint256
+	{input: "80", ptr: new(*uint256.Int), value: uint256.NewInt(0)},
+	{input: "01", ptr: new(*uint256.Int), value: uint256.NewInt(1)},
+	{input: "10", ptr: new(uint256.Int), value: *uint256.NewInt(16)},
 
 	// structs
 	{

--- a/types/rlp/encode_test.go
+++ b/types/rlp/encode_test.go
@@ -26,6 +26,8 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+
+	"github.com/holiman/uint256"
 )
 
 type testEncoder struct {
@@ -146,6 +148,21 @@ var encTests = []encTest{
 
 	// negative ints are not supported
 	{val: big.NewInt(-1), error: "rlp: cannot encode negative *big.Int"},
+
+	// uint256
+	{val: uint256.NewInt(0), output: "80"},
+	{val: uint256.NewInt(0xFFFFFF), output: "83FFFFFF"},
+	{
+		val:    uint256.NewInt(0).SetBytes(unhex("102030405060708090A0B0C0D0E0F2")),
+		output: "8F102030405060708090A0B0C0D0E0F2",
+	},
+
+	// non-pointer uint256
+	{val: *uint256.NewInt(0), output: "80"},
+	{val: *uint256.NewInt(0xFFFFFF), output: "83FFFFFF"},
+
+	// struct
+	{val: simpleUint256{}, output: "C28080"},
 
 	// byte arrays
 	{val: [0]byte{}, output: "80"},


### PR DESCRIPTION
## Description

The Balance field should use the uint256 type. Change its type from bigInt to uint256 to avoid unnecessary casting when integrating with other libraries like Aida.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (changes that do NOT affect functionality)

