### PR TITLE
Add ignore patterns for Codecov to exclude generated and test files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,4 @@ coverage:
 ignore:
   - "**/*.pb.go"
   - "**/*_test.go"
+  - "**/*_mock.go"

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,7 @@ coverage:
       default: # status check name
         target: 80% # target coverage of the changes
         threshold: 0% # allow the coverage to drop by <threshold>%
+
+ignore:
+  - "**/*.pb.go"
+  - "**/*_test.go"


### PR DESCRIPTION
## Description

Ignore all *.pb.go, *_test.go, *_mock.go

## Type of change

- [x] Refactoring (changes that do NOT affect functionality)

