### PR TITLE
Support protobuf encoding alias

### DIFF
--- a/db/substate_encoding.go
+++ b/db/substate_encoding.go
@@ -14,9 +14,10 @@ import (
 type SubstateEncodingSchema string
 
 const (
-	DefaultEncodingSchema  SubstateEncodingSchema = "default"
-	ProtobufEncodingSchema SubstateEncodingSchema = "protobuf"
-	RLPEncodingSchema      SubstateEncodingSchema = "rlp"
+	DefaultEncodingSchema       SubstateEncodingSchema = "default"
+	ProtobufEncodingSchema      SubstateEncodingSchema = "protobuf"
+	RLPEncodingSchema           SubstateEncodingSchema = "rlp"
+	LegacyProtobufEncodingAlias SubstateEncodingSchema = "pb"
 )
 
 // SetSubstateEncoding sets the runtime encoding/decoding behavior of substateDB
@@ -71,7 +72,7 @@ func newSubstateEncoding(encoding SubstateEncodingSchema, lookup codeLookupFunc)
 			encode: encodeRlp,
 		}, nil
 
-	case "", DefaultEncodingSchema, ProtobufEncodingSchema:
+	case "", DefaultEncodingSchema, ProtobufEncodingSchema, LegacyProtobufEncodingAlias:
 		return &substateEncoding{
 			schema: ProtobufEncodingSchema,
 			decode: func(bytes []byte, block uint64, tx int) (*substate.Substate, error) {


### PR DESCRIPTION
## Description

This PR introduce additional encoding keyword `LegacyProtobufEncodingAlias` which allows current testing scripts to run normally. 

Background: Aida accepts `pb` for protobuf encoding before change #36 and many test scripts already uses `pb` in the scripts. To ensure smooth testing, this PR reintroduces `pb` keyword.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (changes that do NOT affect functionality)
- [x] Adds or updates testing
- [ ] This change requires a documentation update
