### PR TITLE
Fix race condition when writing error in iterator

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
         stage('Run go tests') {
             steps {
                 sh 'go mod tidy'
-                sh 'go test ./... -timeout 30m'
+                sh 'go test -race ./... -timeout 30m'
             }
         }
     }

--- a/db/exception_iterator.go
+++ b/db/exception_iterator.go
@@ -94,7 +94,7 @@ func (i *exceptionIterator) start(numWorkers int) {
 					}
 					transaction, err := i.decode(raw)
 					if err != nil {
-						i.err = err
+						i.setError(err)
 						errCh <- err
 						return
 					}

--- a/db/substate_iterator.go
+++ b/db/substate_iterator.go
@@ -94,7 +94,7 @@ func (i *substateIterator) start(numWorkers int) {
 					}
 					transaction, err := i.decode(raw)
 					if err != nil {
-						i.err = err
+						i.setError(err)
 						errCh <- err
 						return
 					}

--- a/db/update_set_iterator.go
+++ b/db/update_set_iterator.go
@@ -78,7 +78,7 @@ func (i *updateSetIterator) start(_ int) {
 			// This avoids filling channels which huge data objects that are not consumed.
 			block, err := DecodeUpdateSetKey(key)
 			if err != nil {
-				i.err = err
+				i.setError(err)
 				return
 			}
 			if block > i.endBlock {
@@ -92,7 +92,7 @@ func (i *updateSetIterator) start(_ int) {
 
 			us, err := i.decode(raw)
 			if err != nil {
-				i.err = err
+				i.setError(err)
 				return
 			}
 


### PR DESCRIPTION
## Description

This PR fixes race condition causes by multiple threads updating `i.err` in iterator. The solution in this PR introduces mutex to guarantee sequential access. Lock should not slow down the process much as it is behind a condition `err != nil` and often that program terminates when an error is detected. In a normal execution flow. Lock mutex is not used.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (changes that do NOT affect functionality)
- [ ] Adds or updates testing
- [ ] This change requires a documentation update
