### PR TITLE
change deafault encoding of updatedb and deletiondb to rlp

### DIFF
--- a/db/destroyed_account_db.go
+++ b/db/destroyed_account_db.go
@@ -52,7 +52,7 @@ func NewDefaultDestroyedAccountDB(destroyedAccountDir string) (DestroyedAccountD
 }
 
 func MakeDefaultDestroyedAccountDBFromBaseDB(db BaseDB) (DestroyedAccountDB, error) {
-	value, err := MakeDefaultDestroyedAccountDBFromBaseDBWithEncoding(db, db.GetSubstateEncoding())
+	value, err := MakeDefaultDestroyedAccountDBFromBaseDBWithEncoding(db, RLPEncodingSchema)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func newDestroyedAccountDB(destroyedAccountDir string, o *opt.Options, wo *opt.W
 	if err != nil {
 		return nil, fmt.Errorf("error opening deletion-db %s: %w", destroyedAccountDir, err)
 	}
-	encoding, err := newDestroyedAccountEncoding(DefaultEncodingSchema)
+	encoding, err := newDestroyedAccountEncoding(RLPEncodingSchema)
 	if err != nil {
 		return nil, err
 	}

--- a/db/destroyed_account_db_test.go
+++ b/db/destroyed_account_db_test.go
@@ -74,11 +74,6 @@ func TestDestroyedAccountDB_GetDestroyedAccountsSuccess(t *testing.T) {
 			schema:   RLPEncodingSchema,
 			encodeFn: encodeSuicidedAccountListRLP,
 		},
-		{
-			name:     "PB Encoding",
-			schema:   ProtobufEncodingSchema,
-			encodeFn: encodeSuicidedAccountListPB,
-		},
 	}
 
 	for _, tc := range testCases {
@@ -140,11 +135,6 @@ func TestDestroyedAccountDB_GetAccountsDestroyedInRangeSuccess(t *testing.T) {
 			name:     "RLP Encoding",
 			schema:   RLPEncodingSchema,
 			encodeFn: encodeSuicidedAccountListRLP,
-		},
-		{
-			name:     "PB Encoding",
-			schema:   ProtobufEncodingSchema,
-			encodeFn: encodeSuicidedAccountListPB,
 		},
 	}
 

--- a/db/destroyed_account_encoding.go
+++ b/db/destroyed_account_encoding.go
@@ -39,18 +39,14 @@ type destroyedAccountEncoding struct {
 
 func newDestroyedAccountEncoding(encoding SubstateEncodingSchema) (*destroyedAccountEncoding, error) {
 	switch encoding {
-	case DefaultEncodingSchema, ProtobufEncodingSchema:
-		return &destroyedAccountEncoding{
-			schema: ProtobufEncodingSchema,
-			encode: encodeSuicidedAccountListPB,
-			decode: decodeSuicidedAccountListPB,
-		}, nil
-	case RLPEncodingSchema:
+	case DefaultEncodingSchema, RLPEncodingSchema:
 		return &destroyedAccountEncoding{
 			schema: RLPEncodingSchema,
 			encode: encodeSuicidedAccountListRLP,
 			decode: decodeSuicidedAccountListRLP,
 		}, nil
+	case ProtobufEncodingSchema:
+		return nil, fmt.Errorf("protobuf encoding is disabled for destroyed account db")
 	default:
 		return nil, fmt.Errorf("encoding not supported: %s", encoding)
 	}

--- a/db/destroyed_account_encoding_test.go
+++ b/db/destroyed_account_encoding_test.go
@@ -56,6 +56,7 @@ func TestDestroyedAccountDB_Encode(t *testing.T) {
 
 	actual, err := db.Encode(SuicidedAccountLists{})
 	assert.NoError(t, err)
+	// RLP encoding header
 	// 0xc2 = list prefix for 2 bytes
 	// 0xc0 = empty list (DestroyedAccounts)
 	// 0xc0 = empty list (ResurrectedAccounts)

--- a/db/destroyed_account_encoding_test.go
+++ b/db/destroyed_account_encoding_test.go
@@ -18,7 +18,7 @@ func TestDestroyedAccountDB_GetSubstateEncoding(t *testing.T) {
 	db := newTestDestroyedAccountDB(t, baseDb, DefaultEncodingSchema)
 
 	actual := db.GetSubstateEncoding()
-	assert.Equal(t, ProtobufEncodingSchema, actual)
+	assert.Equal(t, RLPEncodingSchema, actual)
 }
 
 func TestDestroyedAccountDB_SetSubstateEncoding(t *testing.T) {
@@ -27,17 +27,21 @@ func TestDestroyedAccountDB_SetSubstateEncoding(t *testing.T) {
 
 	baseDb := NewMockDbAdapter(ctrl)
 	db := newTestDestroyedAccountDB(t, baseDb, DefaultEncodingSchema)
-	err := db.SetSubstateEncoding(DefaultEncodingSchema)
-	assert.Nil(t, err)
-	assert.Equal(t, ProtobufEncodingSchema, db.GetSubstateEncoding())
-
-	err = db.SetSubstateEncoding(RLPEncodingSchema)
+	// Test setting to RLP
+	err := db.SetSubstateEncoding(RLPEncodingSchema)
 	assert.Nil(t, err)
 	assert.Equal(t, RLPEncodingSchema, db.GetSubstateEncoding())
 
+	// Test setting to Protobuf (should error)
 	err = db.SetSubstateEncoding(ProtobufEncodingSchema)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to set decoder; protobuf encoding is disabled for destroyed account db", err.Error())
+	assert.Equal(t, RLPEncodingSchema, db.GetSubstateEncoding()) // Should remain RLP
+
+	// Test setting to Default (should map to RLP)
+	err = db.SetSubstateEncoding(DefaultEncodingSchema)
 	assert.Nil(t, err)
-	assert.Equal(t, ProtobufEncodingSchema, db.GetSubstateEncoding())
+	assert.Equal(t, RLPEncodingSchema, db.GetSubstateEncoding())
 
 	err = db.SetSubstateEncoding("invalid")
 	assert.Error(t, err)
@@ -52,7 +56,10 @@ func TestDestroyedAccountDB_Encode(t *testing.T) {
 
 	actual, err := db.Encode(SuicidedAccountLists{})
 	assert.NoError(t, err)
-	assert.Equal(t, []uint8([]byte{}), actual)
+	// 0xc2 = list prefix for 2 bytes
+	// 0xc0 = empty list (DestroyedAccounts)
+	// 0xc0 = empty list (ResurrectedAccounts)
+	assert.Equal(t, []uint8{0xc2, 0xc0, 0xc0}, actual)
 }
 
 func TestDestroyedAccountDB_Decode(t *testing.T) {
@@ -62,19 +69,22 @@ func TestDestroyedAccountDB_Decode(t *testing.T) {
 	baseDb := NewMockDbAdapter(ctrl)
 	db := newTestDestroyedAccountDB(t, baseDb, DefaultEncodingSchema)
 
-	actual, err := db.Decode([]uint8([]byte{}))
+	actual, err := db.Decode([]uint8{0xc2, 0xc0, 0xc0})
 	assert.NoError(t, err)
-	assert.Equal(t, SuicidedAccountLists{}, actual)
+	assert.Equal(t, SuicidedAccountLists{
+		DestroyedAccounts:   []types.Address{},
+		ResurrectedAccounts: []types.Address{},
+	}, actual)
 }
 
 func TestDestroyedAccountEncoding_newDestroyedAccountEncoding(t *testing.T) {
 	encoding, err := newDestroyedAccountEncoding(DefaultEncodingSchema)
 	assert.NoError(t, err)
-	assert.Equal(t, ProtobufEncodingSchema, encoding.schema)
+	assert.Equal(t, RLPEncodingSchema, encoding.schema)
 
 	encoding, err = newDestroyedAccountEncoding(ProtobufEncodingSchema)
-	assert.NoError(t, err)
-	assert.Equal(t, ProtobufEncodingSchema, encoding.schema)
+	assert.Error(t, err)
+	assert.Nil(t, encoding)
 
 	encoding, err = newDestroyedAccountEncoding(RLPEncodingSchema)
 	assert.NoError(t, err)

--- a/db/update_db.go
+++ b/db/update_db.go
@@ -62,7 +62,7 @@ func NewUpdateDB(path string, o *opt.Options, wo *opt.WriteOptions, ro *opt.Read
 }
 
 func MakeDefaultUpdateDBFromBaseDB(db BaseDB) (UpdateDB, error) {
-	value, err := MakeDefaultUpdateDBFromBaseDBWithEncoding(db, db.GetSubstateEncoding())
+	value, err := MakeDefaultUpdateDBFromBaseDBWithEncoding(db, RLPEncodingSchema)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func newUpdateDB(path string, o *opt.Options, wo *opt.WriteOptions, ro *opt.Read
 	if err != nil {
 		return nil, err
 	}
-	encoding, err := newUpdateSetEncoding(DefaultEncodingSchema)
+	encoding, err := newUpdateSetEncoding(RLPEncodingSchema)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create default update-db encoding: %v", err)
 	}

--- a/db/update_db_test.go
+++ b/db/update_db_test.go
@@ -48,7 +48,6 @@ func TestUpdateDB_PutUpdateSet(t *testing.T) {
 		schema SubstateEncodingSchema
 	}{
 		{"RLP", RLPEncodingSchema},
-		{"PB", ProtobufEncodingSchema},
 	}
 
 	for _, tc := range testCases {
@@ -96,7 +95,6 @@ func TestUpdateDB_GetUpdateSet(t *testing.T) {
 		schema SubstateEncodingSchema
 	}{
 		{"RLP", RLPEncodingSchema},
-		{"PB", ProtobufEncodingSchema},
 	}
 
 	for _, tc := range testCases {
@@ -216,7 +214,7 @@ func TestUpdateDB_GetFirstKeySuccess(t *testing.T) {
 
 	mockDB.EXPECT().newIterator(gomock.Any()).Return(mockIter)
 
-	db := newTestUpdateDB(t, mockDB, ProtobufEncodingSchema)
+	db := newTestUpdateDB(t, mockDB, RLPEncodingSchema)
 
 	result, err := db.GetFirstKey()
 
@@ -233,7 +231,7 @@ func TestUpdateDB_GetFirstKeyFail(t *testing.T) {
 	// case 1 not found
 	kv := &testutil.KeyValue{}
 	mockIter := iterator.NewArrayIterator(kv)
-	db := newTestUpdateDB(t, mockDB, ProtobufEncodingSchema)
+	db := newTestUpdateDB(t, mockDB, RLPEncodingSchema)
 
 	mockDB.EXPECT().newIterator(gomock.Any()).Return(mockIter)
 
@@ -267,7 +265,7 @@ func TestUpdateDB_GetLastKeySuccess(t *testing.T) {
 
 	mockDB.EXPECT().newIterator(gomock.Any()).Return(mockIter)
 
-	db := newTestUpdateDB(t, mockDB, ProtobufEncodingSchema)
+	db := newTestUpdateDB(t, mockDB, RLPEncodingSchema)
 
 	result, err := db.GetLastKey()
 
@@ -284,7 +282,7 @@ func TestUpdateDB_GetLastKeyFail(t *testing.T) {
 	// case 1: no updateset found
 	kv := &testutil.KeyValue{}
 	mockIter := iterator.NewArrayIterator(kv)
-	db := newTestUpdateDB(t, mockDB, ProtobufEncodingSchema)
+	db := newTestUpdateDB(t, mockDB, RLPEncodingSchema)
 
 	mockDB.EXPECT().newIterator(gomock.Any()).Return(mockIter)
 
@@ -317,7 +315,7 @@ func TestUpdateDB_HasUpdateSetSuccess(t *testing.T) {
 
 	mockDB.EXPECT().Has(key).Return(true, nil)
 
-	db := newTestUpdateDB(t, mockDB, ProtobufEncodingSchema)
+	db := newTestUpdateDB(t, mockDB, RLPEncodingSchema)
 	result, err := db.HasUpdateSet(blockNum)
 
 	assert.Nil(t, err)
@@ -335,7 +333,7 @@ func TestUpdateDB_HasUpdateSetFail(t *testing.T) {
 
 	mockDB.EXPECT().Has(key).Return(false, expectedErr)
 
-	db := newTestUpdateDB(t, mockDB, ProtobufEncodingSchema)
+	db := newTestUpdateDB(t, mockDB, RLPEncodingSchema)
 	result, err := db.HasUpdateSet(blockNum)
 
 	assert.Equal(t, expectedErr, err)
@@ -355,9 +353,9 @@ func TestUpdateDB_GetUpdateSetSuccess(t *testing.T) {
 		Block:           0,
 		DeletedAccounts: []types.Address{},
 	}
-	encodedData, _ := encodeUpdateSetPB(*updateSet, []types.Address{{}})
+	encodedData, _ := encodeUpdateSetRLP(*updateSet, []types.Address{{}})
 
-	db := newTestUpdateDB(t, mockDB, ProtobufEncodingSchema)
+	db := newTestUpdateDB(t, mockDB, RLPEncodingSchema)
 
 	// case 1: Get success
 	mockDB.EXPECT().Get(key).Return(encodedData, nil)
@@ -389,7 +387,7 @@ func TestUpdateDB_GetUpdateSetFail(t *testing.T) {
 	expectedErr := errors.New("database error")
 	mockDB.EXPECT().Get(key).Return(nil, expectedErr)
 
-	db := newTestUpdateDB(t, mockDB, ProtobufEncodingSchema)
+	db := newTestUpdateDB(t, mockDB, RLPEncodingSchema)
 	result, err := db.GetUpdateSet(blockNum)
 
 	assert.Error(t, err)
@@ -429,7 +427,7 @@ func TestUpdateDB_PutUpdateSetSuccess(t *testing.T) {
 	mockDB.EXPECT().PutCode(gomock.Any()).Return(nil)
 	mockDB.EXPECT().Put(key, gomock.Any()).Return(nil)
 
-	db := newTestUpdateDB(t, mockDB, ProtobufEncodingSchema)
+	db := newTestUpdateDB(t, mockDB, RLPEncodingSchema)
 	err := db.PutUpdateSet(updateSet, deletedAccounts)
 
 	assert.Nil(t, err)
@@ -458,7 +456,7 @@ func TestUpdateDB_PutUpdateSetFail(t *testing.T) {
 	// Case 1: PutCode error
 	mockDB.EXPECT().PutCode(gomock.Any()).Return(expectedErr)
 
-	db := newTestUpdateDB(t, mockDB, ProtobufEncodingSchema)
+	db := newTestUpdateDB(t, mockDB, RLPEncodingSchema)
 	err := db.PutUpdateSet(updateSet, deletedAccounts)
 
 	assert.Equal(t, expectedErr, err)
@@ -481,7 +479,7 @@ func TestUpdateDB_DeleteUpdateSetSuccess(t *testing.T) {
 
 	mockDB.EXPECT().Delete(key).Return(nil)
 
-	db := newTestUpdateDB(t, mockDB, ProtobufEncodingSchema)
+	db := newTestUpdateDB(t, mockDB, RLPEncodingSchema)
 	err := db.DeleteUpdateSet(blockNum)
 
 	assert.Nil(t, err)
@@ -498,7 +496,7 @@ func TestUpdateDB_DeleteUpdateSetFail(t *testing.T) {
 
 	mockDB.EXPECT().Delete(key).Return(expectedErr)
 
-	db := newTestUpdateDB(t, mockDB, ProtobufEncodingSchema)
+	db := newTestUpdateDB(t, mockDB, RLPEncodingSchema)
 	err := db.DeleteUpdateSet(blockNum)
 
 	assert.Equal(t, expectedErr, err)
@@ -509,7 +507,7 @@ func TestUpdateDB_NewUpdateSetIterator(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := NewMockCodeDB(ctrl)
-	db := newTestUpdateDB(t, mockDB, ProtobufEncodingSchema)
+	db := newTestUpdateDB(t, mockDB, RLPEncodingSchema)
 
 	start := uint64(1)
 	end := uint64(4)
@@ -521,7 +519,7 @@ func TestUpdateDB_NewUpdateSetIterator(t *testing.T) {
 		Block:           0,
 		DeletedAccounts: []types.Address{},
 	}
-	encodedData, err := encodeUpdateSetPB(*updateSet, []types.Address{{}})
+	encodedData, err := encodeUpdateSetRLP(*updateSet, []types.Address{{}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/db/update_set_encoding.go
+++ b/db/update_set_encoding.go
@@ -35,18 +35,14 @@ type updateSetEncoding struct {
 
 func newUpdateSetEncoding(encoding SubstateEncodingSchema) (*updateSetEncoding, error) {
 	switch encoding {
-	case DefaultEncodingSchema, ProtobufEncodingSchema:
-		return &updateSetEncoding{
-			schema: ProtobufEncodingSchema,
-			encode: encodeUpdateSetPB,
-			decode: decodeUpdateSetPB,
-		}, nil
-	case RLPEncodingSchema:
+	case DefaultEncodingSchema, RLPEncodingSchema:
 		return &updateSetEncoding{
 			schema: RLPEncodingSchema,
 			encode: encodeUpdateSetRLP,
 			decode: decodeUpdateSetRLP,
 		}, nil
+	case ProtobufEncodingSchema:
+		return nil, fmt.Errorf("protobuf encoding is disabled for update set db")
 	default:
 		return nil, fmt.Errorf("encoding not supported: %s", encoding)
 	}

--- a/db/update_set_encoding_test.go
+++ b/db/update_set_encoding_test.go
@@ -19,10 +19,10 @@ func TestUpdateDB_GetSubstateEncoding(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := NewMockCodeDB(ctrl)
-	db := newTestUpdateDB(t, mockDB, ProtobufEncodingSchema)
+	db := newTestUpdateDB(t, mockDB, RLPEncodingSchema)
 
 	encoding := db.GetSubstateEncoding()
-	assert.Equal(t, ProtobufEncodingSchema, encoding)
+	assert.Equal(t, RLPEncodingSchema, encoding)
 }
 
 func TestUpdateDB_SetSubstateEncoding(t *testing.T) {
@@ -30,22 +30,23 @@ func TestUpdateDB_SetSubstateEncoding(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := NewMockCodeDB(ctrl)
-	db := newTestUpdateDB(t, mockDB, ProtobufEncodingSchema)
+	db := newTestUpdateDB(t, mockDB, RLPEncodingSchema)
 
 	// Test setting to RLP
 	err := db.SetSubstateEncoding(RLPEncodingSchema)
 	assert.Nil(t, err)
 	assert.Equal(t, RLPEncodingSchema, db.encoding.schema)
 
-	// Test setting to Protobuf
+	// Test setting to Protobuf (should error)
 	err = db.SetSubstateEncoding(ProtobufEncodingSchema)
-	assert.Nil(t, err)
-	assert.Equal(t, ProtobufEncodingSchema, db.encoding.schema)
+	assert.Error(t, err)
+	assert.Equal(t, "protobuf encoding is disabled for update set db", err.Error())
+	assert.Equal(t, RLPEncodingSchema, db.encoding.schema)
 
-	// Test setting to Default (should map to Protobuf)
+	// Test setting to Default (should map to RLP)
 	err = db.SetSubstateEncoding(DefaultEncodingSchema)
 	assert.Nil(t, err)
-	assert.Equal(t, ProtobufEncodingSchema, db.encoding.schema)
+	assert.Equal(t, RLPEncodingSchema, db.encoding.schema)
 
 	// Test setting to an unknown schema
 	err = db.SetSubstateEncoding(SubstateEncodingSchema("unknown"))
@@ -56,11 +57,11 @@ func TestUpdateDB_SetSubstateEncoding(t *testing.T) {
 func TestUpdateSetEncoding_newUpdateSetEncoding(t *testing.T) {
 	encoding, err := newUpdateSetEncoding(DefaultEncodingSchema)
 	assert.NoError(t, err)
-	assert.Equal(t, ProtobufEncodingSchema, encoding.schema)
+	assert.Equal(t, RLPEncodingSchema, encoding.schema)
 
 	encoding, err = newUpdateSetEncoding(ProtobufEncodingSchema)
-	assert.NoError(t, err)
-	assert.Equal(t, ProtobufEncodingSchema, encoding.schema)
+	assert.Error(t, err)
+	assert.Nil(t, encoding)
 
 	encoding, err = newUpdateSetEncoding(RLPEncodingSchema)
 	assert.NoError(t, err)

--- a/db/update_set_encoding_test.go
+++ b/db/update_set_encoding_test.go
@@ -40,7 +40,7 @@ func TestUpdateDB_SetSubstateEncoding(t *testing.T) {
 	// Test setting to Protobuf (should error)
 	err = db.SetSubstateEncoding(ProtobufEncodingSchema)
 	assert.Error(t, err)
-	assert.Equal(t, "protobuf encoding is disabled for update set db", err.Error())
+	assert.Equal(t, "failed to set decoder; protobuf encoding is disabled for update set db", err.Error())
 	assert.Equal(t, RLPEncodingSchema, db.encoding.schema)
 
 	// Test setting to Default (should map to RLP)


### PR DESCRIPTION
## Description

This PR changes default encoding of deletionDB and updateDB to match our current dataset (Sonic substate).


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (changes that do NOT affect functionality)
- [ ] Adds or updates testing
- [ ] This change requires a documentation update
